### PR TITLE
Fix broken scoring and detection logic across DOM and HAR rules

### DIFF
--- a/lib/dom/performance/firstContentfulPaint.js
+++ b/lib/dom/performance/firstContentfulPaint.js
@@ -9,7 +9,7 @@
   if (fcpArray.length > 0) {
     const fcp = fcpArray[0].startTime;
     if (fcp <= good) {
-      `First contentful paint is good ${util.ms(fcp)}.`;
+      advice = `First contentful paint is good ${util.ms(fcp)}.`;
     } else if (fcp <= needImprovement) {
       score = 50;
       advice = `First contentful paint can be improved (${util.ms(

--- a/lib/dom/performance/largestContentfulPaint.js
+++ b/lib/dom/performance/largestContentfulPaint.js
@@ -26,7 +26,7 @@
           : ''
       };
       if (lcp.renderTime <= good) {
-        `Largest contentful paint is good ${util.ms(lcp.renderTime)}.`;
+        advice = `Largest contentful paint is good ${util.ms(lcp.renderTime)}.`;
       } else if (lcp.renderTime <= needImprovement) {
         score = 80;
         advice = `Largest contentful paint can be improved ${util.ms(
@@ -37,7 +37,7 @@
         score = 0;
         advice = `Largest contentful paint is poor ${util.ms(
           lcp.renderTime
-        )}. It is in the Google Web Vitals poor range, slower than 4.5 seconds.`;
+        )}. It is in the Google Web Vitals poor range, slower than 4 seconds.`;
         offending.push(lcp.url || lcp.tag);
       }
 

--- a/lib/dom/timings/fullyLoaded.js
+++ b/lib/dom/timings/fullyLoaded.js
@@ -7,7 +7,7 @@
     const resources = window.performance.getEntriesByType('resource');
     let max = 0;
 
-    for (let i = 1, len = resources.length; i < len; i++) {
+    for (let i = 0, len = resources.length; i < len; i++) {
       if (resources[i].responseEnd > max) {
         max = resources[i].responseEnd;
       }

--- a/lib/har/bestpractice/unnecessaryHeaders.js
+++ b/lib/har/bestpractice/unnecessaryHeaders.js
@@ -29,7 +29,7 @@ module.exports = {
       if (
         headers.expires &&
         headers['cache-control'] &&
-        headers['cache-control'][0].indexOf('max-age' > -1)
+        headers['cache-control'][0].indexOf('max-age') > -1
       ) {
         // You don't need to set both expires and cache-control: max-age. Use just one!
         offending.push(asset.url);

--- a/lib/har/privacy/strictTransportSecurityHeader.js
+++ b/lib/har/privacy/strictTransportSecurityHeader.js
@@ -14,12 +14,10 @@ module.exports = {
     let advice = '';
     const finalUrl = page.finalUrl;
     if (finalUrl.indexOf('https://') > -1) {
-      score;
       page.assets.forEach(function (asset) {
         if (asset.url === finalUrl) {
           const headers = asset.headers.response;
           if (headers['strict-transport-security']) {
-            score = 100;
             const h = headers['strict-transport-security'][0];
             if (h.indexOf('includeSubDomains') === -1) {
               score = 90;
@@ -33,9 +31,8 @@ module.exports = {
             } else {
               const parts = h.split(';');
               if (parts[0].startsWith('max-age=')) {
-                const time = parts[0].substring(
-                  parts[0].indexOf('=') + 1,
-                  parts[0].length
+                const time = Number(
+                  parts[0].substring(parts[0].indexOf('=') + 1, parts[0].length)
                 );
                 const minSixMonth = 15768000;
                 if (time < minSixMonth) {
@@ -46,15 +43,13 @@ module.exports = {
               }
             }
           } else {
+            score = 0;
             offending.push(asset.url);
+            advice =
+              'Set a strict transport header to make sure the user always use HTTPS.';
           }
         }
       });
-    }
-    if (score === undefined) {
-      advice =
-        'Set a strict transport header to make sure the user always use HTTPS.';
-      score = 0;
     }
     return {
       score: score,

--- a/lib/har/privacy/thirdPartyCookies.js
+++ b/lib/har/privacy/thirdPartyCookies.js
@@ -14,7 +14,7 @@ module.exports = {
     const thirdPartyCookies = page.cookieNamesThirdParties;
     for (let cookie of thirdPartyCookies) {
       offending.push(cookie.domain);
-      score = -10;
+      score -= 10;
     }
 
     if (score < 100) {

--- a/lib/har/privacy/thirdPartyPrivacy.js
+++ b/lib/har/privacy/thirdPartyPrivacy.js
@@ -42,8 +42,8 @@ module.exports = {
     }
 
     if (
-      thirdParties.byCategory['survelliance'] &&
-      thirdParties.byCategory['survelliance'] > 0
+      thirdParties.byCategory['surveillance'] &&
+      thirdParties.byCategory['surveillance'] > 0
     ) {
       score = 0;
       advice +=

--- a/lib/har/thirdParty.js
+++ b/lib/har/thirdParty.js
@@ -43,17 +43,18 @@ module.exports.getThirdParty = function (page) {
       if (asset.transferSize) {
         thirdPartyTransferSizeBytes += asset.transferSize;
       }
+      let categories = entity.categories;
       if (
         entity.name.indexOf('Google') > -1 ||
         entity.name.indexOf('Facebook') > -1 ||
         entity.name.indexOf('AMP') > -1 ||
         entity.name.indexOf('YouTube') > -1
       ) {
-        if (!entity.categories.includes('survelliance')) {
-          entity.categories.push('survelliance');
+        if (!categories.includes('surveillance')) {
+          categories = categories.concat('surveillance');
         }
       }
-      for (let category of entity.categories) {
+      for (let category of categories) {
         if (!toolsByCategory[category]) {
           toolsByCategory[category] = {};
         }

--- a/test/har/bestpractice/unnecessaryHeadersTest.js
+++ b/test/har/bestpractice/unnecessaryHeadersTest.js
@@ -8,12 +8,12 @@ describe('Investigate response headers for headers we do not need', function() {
     return har.firstAdviceForTestFile('unnecessaryHeaders.har').then(result => {
       assert.strictEqual(
         result.bestpractice.adviceList.unnecessaryHeaders.offending.length,
-        17,
+        16,
         result.bestpractice.adviceList.unnecessaryHeaders.advice
       );
       assert.strictEqual(
         result.bestpractice.adviceList.unnecessaryHeaders.score,
-        83,
+        84,
         result.bestpractice.adviceList.unnecessaryHeaders.advice
       );
     });


### PR DESCRIPTION
Several rules were silently returning the wrong score because of small
  typos and dead branches that had been there for years. The most
  load-bearing one is HSTS: an HTTPS page with no Strict-Transport-Security
  header was scoring 100 with no advice, instead of failing the rule.
  Other fixes recover advice text that was being dropped (FCP, LCP), make
  third-party-cookie scoring actually scale with the number of cookies,
  let the unnecessary-headers rule notice cache-control + expires combos,
  and stop mutating the third-party-web entity cache from inside the
  runner.

  The misspelled "survelliance" category leaked into the HAR result
  (info.thirdParty.requestsByCategory). Fixing it changes the key any
  external consumer would see — that's a small but visible behaviour
  change worth calling out in release notes.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com