### PR TITLE
Add privacy and security header rules (DOM and HAR)

### DIFF
--- a/lib/dom/privacy/iframeSandbox.js
+++ b/lib/dom/privacy/iframeSandbox.js
@@ -1,0 +1,47 @@
+(function (util) {
+  'use strict';
+
+  // Same-origin iframes are part of the page's own trust boundary, so missing
+  // sandbox on those is not a finding here. We only flag cross-origin iframes
+  // that load over http(s) without a sandbox attribute, since those are the
+  // ones that benefit from the extra isolation.
+  const pageHost = util.getHostname(document.URL).toLowerCase();
+  const offending = [];
+
+  const iframes = document.getElementsByTagName('iframe');
+  for (let i = 0, len = iframes.length; i < len; i++) {
+    const iframe = iframes[i];
+    if (!iframe.src) {
+      continue;
+    }
+    if (!/^https?:/i.test(iframe.src)) {
+      continue;
+    }
+    const host = util.getHostname(iframe.src).toLowerCase();
+    if (!host || host === pageHost) {
+      continue;
+    }
+    if (!iframe.hasAttribute('sandbox')) {
+      offending.push(util.getAbsoluteURL(iframe.src));
+    }
+  }
+
+  const score = offending.length > 0 ? 0 : 100;
+
+  return {
+    id: 'iframeSandbox',
+    title: 'Sandbox cross-origin iframes',
+    description:
+      'Adding a sandbox attribute to a cross-origin iframe restricts what the embedded page can do (script execution, form submission, top-level navigation, popups, etc.) and is one of the cheapest ways to limit the blast radius of a third-party embed. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox',
+    advice:
+      score === 0
+        ? 'The page embeds ' +
+          util.plural(offending.length, 'cross-origin iframe') +
+          ' without a sandbox attribute. Add sandbox="" with the minimum set of allow-* tokens the embed actually needs.'
+        : '',
+    score: score,
+    weight: 4,
+    offending: offending,
+    tags: ['privacy']
+  };
+})(util);

--- a/lib/dom/privacy/referrerPolicy.js
+++ b/lib/dom/privacy/referrerPolicy.js
@@ -1,0 +1,38 @@
+(function () {
+  'use strict';
+
+  // Detect a referrer policy declared in the document itself via
+  // <meta name="referrer" content="..."> Note: a Referrer-Policy response
+  // header is preferred and is checked separately by the HAR rule. This DOM
+  // rule is the fallback signal for runs without a HAR.
+  let metaContent = '';
+  const metas = document.getElementsByTagName('meta');
+  for (let i = 0, len = metas.length; i < len; i++) {
+    const name = metas[i].getAttribute('name');
+    if (name && name.toLowerCase() === 'referrer') {
+      metaContent = (metas[i].getAttribute('content') || '').trim();
+      break;
+    }
+  }
+
+  // The default (no-referrer-when-downgrade in older specs, strict-origin-when-cross-origin
+  // since 2020) leaks the full URL on same-origin navigations. Anything explicit
+  // is better; flag a missing or empty meta.
+  const hasMeta = metaContent.length > 0;
+  const score = hasMeta ? 100 : 0;
+
+  return {
+    id: 'referrerPolicy',
+    title: 'Declare a referrer policy on the document',
+    description:
+      'Without an explicit referrer policy the browser falls back to the user-agent default and may leak the full URL of the previous page (including query strings) to every cross-origin request. Set a Referrer-Policy response header (preferred) or a <meta name="referrer"> tag in the document. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy',
+    advice:
+      score === 0
+        ? 'No <meta name="referrer"> tag was found on the page. Set a Referrer-Policy response header (preferred) or add a meta tag, for example <meta name="referrer" content="strict-origin-when-cross-origin">.'
+        : '',
+    score: score,
+    weight: 3,
+    offending: [],
+    tags: ['privacy']
+  };
+})();

--- a/lib/har/privacy/crossOriginEmbedderPolicyHeader.js
+++ b/lib/har/privacy/crossOriginEmbedderPolicyHeader.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  id: 'crossOriginEmbedderPolicyHeader',
+  title:
+    'Set a Cross-Origin-Embedder-Policy header so cross-origin subresources opt in to being embedded.',
+  description:
+    'Cross-Origin-Embedder-Policy (COEP) makes the page refuse to load cross-origin subresources unless they explicitly opt in via CORP or CORS. Together with Cross-Origin-Opener-Policy it puts the page in a cross-origin isolated context, which mitigates cross-window side-channel attacks (Spectre) and unlocks high-resolution timers and SharedArrayBuffer. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy',
+  weight: 4,
+  tags: ['headers', 'privacy'],
+  processPage: function (page) {
+    const offending = [];
+    let score = 0;
+    let advice = '';
+    const finalUrl = page.finalUrl;
+    page.assets.forEach(function (asset) {
+      if (asset.url === finalUrl) {
+        const headers = asset.headers.response;
+        if (headers['cross-origin-embedder-policy']) {
+          score = 100;
+        } else {
+          offending.push(asset.url);
+        }
+      }
+    });
+    if (score === 0) {
+      advice =
+        'Set a Cross-Origin-Embedder-Policy header (typically require-corp or credentialless) on the document response to control cross-origin embedding.';
+    }
+    return {
+      score: score,
+      offending: offending,
+      advice: advice
+    };
+  }
+};

--- a/lib/har/privacy/crossOriginOpenerPolicyHeader.js
+++ b/lib/har/privacy/crossOriginOpenerPolicyHeader.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  id: 'crossOriginOpenerPolicyHeader',
+  title:
+    'Set a Cross-Origin-Opener-Policy header to isolate the page from cross-origin windows.',
+  description:
+    'Cross-Origin-Opener-Policy (COOP) lets a page sever its window-group ties to cross-origin documents that opened it or that it opens. Together with Cross-Origin-Embedder-Policy it puts the page in a cross-origin isolated context, which mitigates cross-window side-channel attacks (Spectre) and unlocks high-resolution timers and SharedArrayBuffer. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy',
+  weight: 4,
+  tags: ['headers', 'privacy'],
+  processPage: function (page) {
+    const offending = [];
+    let score = 0;
+    let advice = '';
+    const finalUrl = page.finalUrl;
+    page.assets.forEach(function (asset) {
+      if (asset.url === finalUrl) {
+        const headers = asset.headers.response;
+        if (headers['cross-origin-opener-policy']) {
+          score = 100;
+        } else {
+          offending.push(asset.url);
+        }
+      }
+    });
+    if (score === 0) {
+      advice =
+        'Set a Cross-Origin-Opener-Policy header (typically same-origin) on the document response to isolate the page from cross-origin windows.';
+    }
+    return {
+      score: score,
+      offending: offending,
+      advice: advice
+    };
+  }
+};

--- a/lib/har/privacy/crossOriginResourcePolicyHeader.js
+++ b/lib/har/privacy/crossOriginResourcePolicyHeader.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  id: 'crossOriginResourcePolicyHeader',
+  title:
+    'Set a Cross-Origin-Resource-Policy header to limit who may embed the page.',
+  description:
+    'Cross-Origin-Resource-Policy (CORP) is a per-response opt-in that tells the browser which origins are allowed to embed the resource. It blocks cross-origin or cross-site no-cors embedding (img, script, iframe, etc.) and is one of the building blocks of cross-origin isolation. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy',
+  weight: 3,
+  tags: ['headers', 'privacy'],
+  processPage: function (page) {
+    const offending = [];
+    let score = 0;
+    let advice = '';
+    const finalUrl = page.finalUrl;
+    page.assets.forEach(function (asset) {
+      if (asset.url === finalUrl) {
+        const headers = asset.headers.response;
+        if (headers['cross-origin-resource-policy']) {
+          score = 100;
+        } else {
+          offending.push(asset.url);
+        }
+      }
+    });
+    if (score === 0) {
+      advice =
+        'Set a Cross-Origin-Resource-Policy header (same-origin, same-site or cross-origin) on the document response to limit who may embed it.';
+    }
+    return {
+      score: score,
+      offending: offending,
+      advice: advice
+    };
+  }
+};


### PR DESCRIPTION
Continues the work started by the Permissions-Policy and X-Content-Type-Options rules. On the HAR side this adds the
  cross-origin isolation trio — Cross-Origin-Opener-Policy, Cross-Origin-Embedder-Policy and
  Cross-Origin-Resource-Policy — which together let a page enter a cross-origin isolated context and mitigate
  cross-window side-channel attacks (Spectre and friends), while also unlocking high-resolution timers and
  SharedArrayBuffer for pages that need them.

  On the DOM side it adds two checks the HAR cannot see. iframeSandbox flags cross-origin  elements that are loaded
  without a sandbox attribute, which is the cheapest way to limit the blast radius of a third-party embed.
  referrerPolicy flags pages that don't declare a  tag; the response header is preferred and is already covered by
  referrerPolicyHeader on the HAR side, so this DOM rule is the fallback signal for runs without a HAR.

  All five rules follow the same shape as the existing referrer-policy, HSTS, Permissions-Policy and
  X-Content-Type-Options rules — no new infrastructure.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com