### PR TITLE
Add viewport and image-alt-text bestpractice rules

### DIFF
--- a/lib/dom/bestpractice/imageAltText.js
+++ b/lib/dom/bestpractice/imageAltText.js
@@ -1,0 +1,43 @@
+(function (util) {
+  'use strict';
+
+  // An <img> needs a textual alternative for assistive tech. The accepted
+  // shapes are: alt="meaningful text" for content images, or alt="" (decorative)
+  // / role="presentation" / aria-hidden="true" for purely decorative images.
+  // A missing alt attribute entirely is the failure case.
+  const offending = [];
+  const images = document.getElementsByTagName('img');
+  for (let i = 0, len = images.length; i < len; i++) {
+    const img = images[i];
+    const hasAlt = img.hasAttribute('alt');
+    const ariaHidden = img.getAttribute('aria-hidden');
+    const role = img.getAttribute('role');
+    const isMarkedDecorative =
+      (ariaHidden && ariaHidden.toLowerCase() === 'true') ||
+      (role && role.toLowerCase() === 'presentation') ||
+      (role && role.toLowerCase() === 'none');
+    if (!hasAlt && !isMarkedDecorative) {
+      offending.push(util.getAbsoluteURL(img.currentSrc || img.src || ''));
+    }
+  }
+
+  const score =
+    offending.length === 0 ? 100 : Math.max(0, 100 - offending.length * 10);
+
+  return {
+    id: 'imageAltText',
+    title: 'Give every image a textual alternative',
+    description:
+      'Every <img> needs an alt attribute. Use alt="meaningful description" for content images so assistive technologies can announce them, or alt="" (or role="presentation" / aria-hidden="true") for purely decorative images so they are skipped. A missing alt attribute leaves screen reader users with no information at all. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#alt',
+    advice:
+      offending.length > 0
+        ? 'The page has ' +
+          util.plural(offending.length, 'image') +
+          ' without an alt attribute. Add alt="..." with a description, or alt="" if the image is purely decorative.'
+        : '',
+    score: score,
+    weight: 4,
+    offending: offending,
+    tags: ['bestpractice', 'accessibility']
+  };
+})(util);

--- a/lib/dom/bestpractice/viewport.js
+++ b/lib/dom/bestpractice/viewport.js
@@ -1,0 +1,59 @@
+(function () {
+  'use strict';
+
+  // A correct viewport meta tag is the baseline for responsive layout on
+  // mobile. Without it the browser uses a desktop-width fallback (typically
+  // 980px) and scales the page down, which makes text unreadable. Locking
+  // user-scalable=no or maximum-scale=1 also breaks pinch-to-zoom and is an
+  // accessibility regression, so we flag those values too.
+  let content = '';
+  const metas = document.getElementsByTagName('meta');
+  for (let i = 0, len = metas.length; i < len; i++) {
+    const name = metas[i].getAttribute('name');
+    if (name && name.toLowerCase() === 'viewport') {
+      content = (metas[i].getAttribute('content') || '').trim();
+      break;
+    }
+  }
+
+  let score = 100;
+  let advice = '';
+  const lower = content.toLowerCase();
+
+  if (content.length === 0) {
+    score = 0;
+    advice =
+      'The page is missing a viewport meta tag. Add <meta name="viewport" content="width=device-width, initial-scale=1"> so the browser lays the page out at the device width.';
+  } else {
+    if (lower.indexOf('width=device-width') === -1) {
+      score -= 50;
+      advice +=
+        'The viewport meta tag does not contain width=device-width, the browser may use a desktop-width fallback. ';
+    }
+    if (
+      lower.indexOf('user-scalable=no') > -1 ||
+      lower.indexOf('user-scalable=0') > -1
+    ) {
+      score -= 30;
+      advice +=
+        'The viewport meta tag disables user-scalable, which breaks pinch-to-zoom and is an accessibility problem. ';
+    }
+    if (/maximum-scale\s*=\s*(0?\.\d+|1(\.0+)?)\b/.test(lower)) {
+      score -= 20;
+      advice +=
+        'The viewport meta tag sets maximum-scale to 1 or less, which prevents the user from zooming in. Remove it. ';
+    }
+  }
+
+  return {
+    id: 'viewport',
+    title: 'Set a sensible viewport meta tag',
+    description:
+      'The viewport meta tag tells the browser how to lay out the page on small screens. Without it (or without width=device-width) the page is rendered at a desktop fallback width and scaled down, which makes text unreadable on mobile. Disabling zoom (user-scalable=no, maximum-scale<=1) is also an accessibility regression. https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag',
+    advice: advice.trim(),
+    score: Math.max(0, score),
+    weight: 5,
+    offending: [],
+    tags: ['bestpractice']
+  };
+})();


### PR DESCRIPTION
Two small accessibility / mobile checks the coach didn't have before but that fail surprisingly often on real sites.

  The viewport rule fails three things: a missing viewport meta tag entirely (browser falls back to a desktop-width
  layout and scales the page down, making text unreadable on mobile), a viewport without width=device-width (same
  outcome), and the patterns that disable pinch-to-zoom — user-scalable=no and maximum-scale<=1. The zoom checks matter
   because those used to be common defaults and they break a real accessibility need; modern browsers ignore them in
  some contexts but not all, so flagging them is still worthwhile.

  The imageAltText rule fails any  that has no alt attribute at all. It deliberately treats alt="", role="presentation"
   / role="none" and aria-hidden="true" as valid markers for purely decorative images, so an image that is correctly
  hidden from assistive tech does not get flagged.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com