### PR TITLE
Add severity tier alongside the existing score and weight

### DIFF
--- a/lib/dom/bestpractice/amp.js
+++ b/lib/dom/bestpractice/amp.js
@@ -20,6 +20,7 @@
         : '',
     score: score,
     weight: 1,
+    severity: 'info',
     offending: offending,
     tags: ['bestpractice']
   };

--- a/lib/dom/bestpractice/charset.js
+++ b/lib/dom/bestpractice/charset.js
@@ -22,6 +22,7 @@
     advice: message,
     score: score,
     weight: 2,
+    severity: 'info',
     offending: [],
     tags: ['bestpractice']
   };

--- a/lib/dom/bestpractice/cumulativeLayoutShift.js
+++ b/lib/dom/bestpractice/cumulativeLayoutShift.js
@@ -52,6 +52,7 @@
     advice,
     score,
     weight: 8,
+    severity: 'error',
     offending,
     tags: ['bestpractice']
   };

--- a/lib/dom/bestpractice/doctype.js
+++ b/lib/dom/bestpractice/doctype.js
@@ -28,6 +28,7 @@
     advice: message,
     score: score,
     weight: 2,
+    severity: 'warn',
     offending: [],
     tags: ['bestpractice']
   };

--- a/lib/dom/bestpractice/language.js
+++ b/lib/dom/bestpractice/language.js
@@ -25,6 +25,7 @@
     advice: message,
     score: score,
     weight: 3,
+    severity: 'warn',
     offending: [],
     tags: ['bestpractice']
   };

--- a/lib/dom/bestpractice/metaDescription.js
+++ b/lib/dom/bestpractice/metaDescription.js
@@ -35,6 +35,7 @@
     advice: message,
     score: score,
     weight: 5,
+    severity: 'info',
     offending: [],
     tags: ['bestpractice']
   };

--- a/lib/dom/bestpractice/optimizely.js
+++ b/lib/dom/bestpractice/optimizely.js
@@ -23,6 +23,7 @@
     advice: advice,
     score: score,
     weight: 2,
+    severity: 'info',
     offending: offending,
     tags: ['bestpractice']
   };

--- a/lib/dom/bestpractice/pageTitle.js
+++ b/lib/dom/bestpractice/pageTitle.js
@@ -26,6 +26,7 @@
     advice: message,
     score: score,
     weight: 5,
+    severity: 'warn',
     offending: [],
     tags: ['bestpractice']
   };

--- a/lib/dom/bestpractice/url.js
+++ b/lib/dom/bestpractice/url.js
@@ -41,6 +41,7 @@
     advice: message,
     score: score < 0 ? 0 : score,
     weight: 2,
+    severity: 'info',
     offending: [],
     tags: ['bestpractice']
   };

--- a/lib/dom/performance/avoidRenderBlocking.js
+++ b/lib/dom/performance/avoidRenderBlocking.js
@@ -93,6 +93,7 @@
     advice: message,
     score: Math.max(0, 100 - score),
     weight: 10,
+    severity: 'warn',
     offending: offending,
     tags: ['performance']
   };

--- a/lib/dom/performance/avoidScalingImages.js
+++ b/lib/dom/performance/avoidScalingImages.js
@@ -35,6 +35,7 @@
     advice: message,
     score: Math.max(0, 100 - score),
     weight: 5,
+    severity: 'warn',
     offending: offending,
     tags: ['performance', 'image']
   };

--- a/lib/dom/performance/cssPrint.js
+++ b/lib/dom/performance/cssPrint.js
@@ -26,6 +26,7 @@
         : '',
     score: Math.max(0, 100 - score),
     weight: 1,
+    severity: 'info',
     offending: offending,
     tags: ['performance', 'css']
   };

--- a/lib/dom/performance/firstContentfulPaint.js
+++ b/lib/dom/performance/firstContentfulPaint.js
@@ -41,6 +41,7 @@
     advice: advice,
     score: Math.max(0, score),
     weight: 7,
+    severity: 'error',
     offending: [],
     tags: ['performance']
   };

--- a/lib/dom/performance/googleTagManager.js
+++ b/lib/dom/performance/googleTagManager.js
@@ -17,6 +17,7 @@
         : '',
     score: score,
     weight: 5,
+    severity: 'info',
     offending: [],
     tags: ['performance', 'js']
   };

--- a/lib/dom/performance/inlineCss.js
+++ b/lib/dom/performance/inlineCss.js
@@ -71,6 +71,7 @@
     advice: message,
     score: Math.max(0, 100 - score),
     weight: 7,
+    severity: 'warn',
     offending: offending,
     tags: ['performance', 'css']
   };

--- a/lib/dom/performance/jquery.js
+++ b/lib/dom/performance/jquery.js
@@ -36,6 +36,7 @@
         : '',
     score: versions.length > 1 ? 0 : 100,
     weight: 1,
+    severity: 'info',
     offending: versions,
     tags: ['jQuery', 'performance']
   };

--- a/lib/dom/performance/largestContentfulPaint.js
+++ b/lib/dom/performance/largestContentfulPaint.js
@@ -64,6 +64,7 @@
     advice: advice,
     score: Math.max(0, score),
     weight: 7,
+    severity: 'error',
     offending: offending,
     tags: ['performance']
   };

--- a/lib/dom/performance/longTasks.js
+++ b/lib/dom/performance/longTasks.js
@@ -58,6 +58,7 @@
         : advice,
     score: Math.max(0, 100 - score),
     weight: 8,
+    severity: 'warn',
     offending: offending,
     tags: ['performance', 'js']
   };

--- a/lib/dom/performance/spof.js
+++ b/lib/dom/performance/spof.js
@@ -47,6 +47,7 @@
         : '',
     score: Math.max(0, 100 - score),
     weight: 7,
+    severity: 'info',
     offending: offending,
     tags: ['performance', 'css', 'js']
   };

--- a/lib/dom/privacy/facebook.js
+++ b/lib/dom/privacy/facebook.js
@@ -19,6 +19,7 @@
         : '',
     score: score,
     weight: 8,
+    severity: 'warn',
     offending: offending,
     tags: ['privacy']
   };

--- a/lib/dom/privacy/fingerprint.js
+++ b/lib/dom/privacy/fingerprint.js
@@ -19,6 +19,7 @@
         : '',
     score: score,
     weight: 8,
+    severity: 'warn',
     offending: offending,
     tags: ['privacy']
   };

--- a/lib/dom/privacy/ga.js
+++ b/lib/dom/privacy/ga.js
@@ -35,6 +35,7 @@
         : '',
     score: score,
     weight: 8,
+    severity: 'warn',
     offending: offending,
     tags: ['privacy']
   };

--- a/lib/dom/privacy/https.js
+++ b/lib/dom/privacy/https.js
@@ -19,6 +19,7 @@
     advice: message,
     score: score,
     weight: 10,
+    severity: 'error',
     offending: [],
     tags: ['privacy']
   };

--- a/lib/dom/privacy/surveillance.js
+++ b/lib/dom/privacy/surveillance.js
@@ -65,6 +65,7 @@
         : '',
     score: score,
     weight: 10,
+    severity: 'warn',
     offending: offending,
     tags: ['privacy']
   };

--- a/lib/dom/privacy/youtube.js
+++ b/lib/dom/privacy/youtube.js
@@ -19,6 +19,7 @@
         : '',
     score: score,
     weight: 6,
+    severity: 'info',
     offending: offending,
     tags: ['privacy']
   };

--- a/lib/har/bestpractice/longHeaders.js
+++ b/lib/har/bestpractice/longHeaders.js
@@ -7,6 +7,7 @@ module.exports = {
   title: 'Do not send too long headers',
   description: 'Do not send response headers that are too long.',
   weight: 1,
+  severity: 'info',
   tags: ['bestpractice', 'header'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/bestpractice/manyHeaders.js
+++ b/lib/har/bestpractice/manyHeaders.js
@@ -7,6 +7,7 @@ module.exports = {
   title: 'Avoid use too many response headers',
   description: 'Avoid send too many response headers.',
   weight: 1,
+  severity: 'info',
   tags: ['bestpractice', 'headers'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/bestpractice/thirdParty.js
+++ b/lib/har/bestpractice/thirdParty.js
@@ -7,6 +7,7 @@ module.exports = {
   title: 'Avoid too many third party requests',
   description: 'Do not load most of your content from third party URLs.',
   weight: 7,
+  severity: 'info',
   tags: ['bestpractice'],
   processPage: function (page) {
     let score = 100;

--- a/lib/har/bestpractice/unnecessaryHeaders.js
+++ b/lib/har/bestpractice/unnecessaryHeaders.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     "Do not send headers that you don't need. We look for p3p, cache-control and max-age, pragma, server and x-frame-options headers. Have a look at Andrew Betts - Headers for Hackers talk as a guide https://www.youtube.com/watch?v=k92ZbrY815c or read https://www.fastly.com/blog/headers-we-dont-want.",
   weight: 1,
+  severity: 'info',
   tags: ['bestpractice', 'header'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/index.js
+++ b/lib/har/index.js
@@ -3,6 +3,7 @@
 const util = require('./util');
 const packageInfo = require('../../package');
 const thirdParty = require('./thirdParty');
+const severity = require('../severity');
 
 module.exports.runAdvice = function (
   pages,
@@ -29,6 +30,7 @@ module.exports.runAdvice = function (
             description: advice.description,
             advice: result.advice,
             weight: advice.weight,
+            severity: advice.severity || severity.fromWeight(advice.weight),
             tags: advice.tags,
             score: result.score,
             offending: result.offending

--- a/lib/har/performance/assetsRedirects.js
+++ b/lib/har/performance/assetsRedirects.js
@@ -14,6 +14,7 @@ module.exports = {
   description:
     'A redirect is one extra step for the user to download the asset. Avoid that if you want to be fast. Redirects are even more of a showstopper on mobile.',
   weight: 2,
+  severity: 'warn',
   tags: ['performance'],
   processPage: function (page) {
     let score = 100;

--- a/lib/har/performance/avoidRenderBlocking.js
+++ b/lib/har/performance/avoidRenderBlocking.js
@@ -6,6 +6,7 @@ module.exports = {
   description:
     'The critical rendering path is what the browser needs to do to start rendering the page. Every file requested inside of the head element will postpone the rendering of the page, because the browser need to do the request. Avoid loading JavaScript synchronously inside of the head (you should not need JavaScript to render the page), request files from the same domain as the main document (to avoid DNS lookups) and inline CSS for really fast rendering and a short rendering path.',
   weight: 10,
+  severity: 'warn',
   tags: ['performance'],
   processPage: function (page, domAdvice, options) {
     let score = 100;

--- a/lib/har/performance/cacheHeaders.js
+++ b/lib/har/performance/cacheHeaders.js
@@ -14,6 +14,7 @@ module.exports = {
   description:
     "The easiest way to make your page fast is to avoid doing requests to the server. Setting a cache header on your server response will tell the browser that it doesn't need to download the asset again during the configured cache time! Always try to set a cache time if the content doesn't change for every request.",
   weight: 30,
+  severity: 'warn',
   tags: ['performance', 'server'],
 
   processPage: function (page) {

--- a/lib/har/performance/cacheHeadersLong.js
+++ b/lib/har/performance/cacheHeadersLong.js
@@ -28,6 +28,7 @@ module.exports = {
   description:
     'Setting a cache header is good. Setting a long cache header (at least 30 days) is even better beacause then it will stay long in the browser cache. But what do you do if that asset change? Rename it and the browser will pick up the new version.',
   weight: 3,
+  severity: 'info',
   tags: ['performance', 'server'],
 
   processPage: function (page) {

--- a/lib/har/performance/compressAssets.js
+++ b/lib/har/performance/compressAssets.js
@@ -28,6 +28,7 @@ module.exports = {
   description:
     "In the early days of the Internet there were browsers that didn't support compressing (gzipping) text content. They do now. Make sure you compress HTML, JSON, JavaScript, CSS and SVG. It will save bytes for the user; making the page load faster and use less bandwith. ",
   weight: 8,
+  severity: 'warn',
   tags: ['performance', 'server'],
 
   processPage: function (page) {

--- a/lib/har/performance/connectionKeepAlive.js
+++ b/lib/har/performance/connectionKeepAlive.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     "Use keep-alive headers and don't close the connection when we have multiple requests to the same domain. There has been some hacks in the past that suggested closing the connection as fast as possible in order to create new ones, but that shouldn't be applicable anymore.",
   weight: 5,
+  severity: 'info',
   tags: ['performance', 'server'],
   processPage: function (page) {
     let score = 100;

--- a/lib/har/performance/cpuTimeSpentInRendering.js
+++ b/lib/har/performance/cpuTimeSpentInRendering.js
@@ -5,6 +5,7 @@ module.exports = {
   description:
     'You need to be able to render the page fast. This metric depends on which computer/device you run on but the limit here is high: Spending more time than 500 ms will alert this advice.',
   weight: 7,
+  severity: 'warn',
   tags: ['performance', 'CSS'],
   processPage: function (page) {
     if (page.cpu && page.cpu.categories) {

--- a/lib/har/performance/cpuTimeSpentInScripting.js
+++ b/lib/har/performance/cpuTimeSpentInScripting.js
@@ -5,6 +5,7 @@ module.exports = {
   description:
     'Do not run too much JavaSript, that will slow down the page for your user. This metric depends on which computer/device you run on but the limit here is high: Spending more time than 1000 ms will alert this advice',
   weight: 7,
+  severity: 'warn',
   tags: ['performance', 'JavaScript'],
   processPage: function (page) {
     if (page.cpu && page.cpu.categories) {

--- a/lib/har/performance/cssSize.js
+++ b/lib/har/performance/cssSize.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     "Delivering a massive amount of CSS to the browser is not the best thing you can do, because it means more work for the browser when parsing the CSS against the HTML and that makes the rendering slower. Try to send only the CSS that is used on that page. And make sure to remove CSS rules when they aren't used anymore.",
   weight: 5,
+  severity: 'warn',
   tags: ['performance', 'css'],
 
   processPage: function (page, domAdvice, options) {

--- a/lib/har/performance/documentRedirect.js
+++ b/lib/har/performance/documentRedirect.js
@@ -6,6 +6,7 @@ module.exports = {
   description:
     "You should never ever redirect the main document, because it will make the page load slower for the user. Well, you should redirect the user if the user tries to use HTTP and there's an HTTPS version of the page. The coach checks for that. :)",
   weight: 9,
+  severity: 'warn',
   tags: ['performance'],
   processPage: function (page) {
     let score = page.documentRedirects > 0 ? 0 : 100;

--- a/lib/har/performance/favicon.js
+++ b/lib/har/performance/favicon.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     "It is easy to make the favicon big but please avoid doing that, because every browser will then perform an unnecessarily large download. And make sure the cache headers are set for a long time for the favicon. It is easy to miss since it's another content type.",
   weight: 1,
+  severity: 'info',
   tags: ['performance', 'favicon'],
 
   processPage: function (page) {

--- a/lib/har/performance/fewFonts.js
+++ b/lib/har/performance/fewFonts.js
@@ -7,6 +7,7 @@ module.exports = {
   description:
     'How many fonts do you need on a page for the user to get the message? Fonts can slow down the rendering of content, try to avoid loading too many of them because worst case it can make the text invisible until they are loaded (FOIT—flash of invisible text), best case they will flicker the text content when they arrive.',
   weight: 2,
+  severity: 'info',
   tags: ['performance', 'font'],
   processPage: function (page) {
     const urls = page.assets

--- a/lib/har/performance/fewRequestsPerDomain.js
+++ b/lib/har/performance/fewRequestsPerDomain.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     'Browsers have a limit on how many concurrent requests they can do per domain when using HTTP/1. When you hit the limit, the browser will wait before it can download more assets on that domain. So avoid having too many requests per domain.',
   weight: 5,
+  severity: 'info',
   tags: ['performance', 'HTTP/1'],
   processPage: function (page) {
     let limit = 30;

--- a/lib/har/performance/headerSize.js
+++ b/lib/har/performance/headerSize.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     'Avoid a lot of cookies and other stuff that makes your headers big when you use HTTP/1 because the headers are not compressed. You will send extra data to the user.',
   weight: 4,
+  severity: 'info',
   tags: ['performance', 'mobile'],
   processPage: function (page) {
     // H2 sends headers compressed and we don't get the right size now

--- a/lib/har/performance/imageSize.js
+++ b/lib/har/performance/imageSize.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     'Avoid having too many large images on the page. The images will not affect the first paint of the page, but it will eat bandwidth for the user.',
   weight: 5,
+  severity: 'warn',
   tags: ['performance', 'image'],
 
   processPage: function (page) {

--- a/lib/har/performance/javascriptSize.js
+++ b/lib/har/performance/javascriptSize.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     'A lot of JavaScript often means you are downloading more than you need. How complex is the page and what can the user do on the page? Do you use multiple JavaScript frameworks?',
   weight: 5,
+  severity: 'warn',
   tags: ['performance', 'javascript'],
 
   processPage: function (page) {

--- a/lib/har/performance/mimeTypes.js
+++ b/lib/har/performance/mimeTypes.js
@@ -7,6 +7,7 @@ module.exports = {
   description:
     "It's not a great idea to let browsers guess content types (content sniffing), in some cases it can actually be a security risk.",
   weight: 0,
+  severity: 'error',
   tags: ['performance', 'bestpractice'],
   processPage: function (page) {
     let score = 100;

--- a/lib/har/performance/optimalCssSize.js
+++ b/lib/har/performance/optimalCssSize.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     'Make CSS responses small to fit into the magic number TCP window size of 14.5 KB. The browser can then download the CSS faster and that will make the page start rendering earlier.',
   weight: 3,
+  severity: 'info',
   tags: ['performance', 'css'],
 
   processPage: function (page) {

--- a/lib/har/performance/pageSize.js
+++ b/lib/har/performance/pageSize.js
@@ -8,6 +8,7 @@ module.exports = {
   description:
     'Avoid having pages that have a transfer size over the wire of more than 2 MB (desktop) and 1 MB (mobile) because that is really big and will hurt performance and will make the page expensive for the user if she/he pays for the bandwidth.',
   weight: 3,
+  severity: 'warn',
   tags: ['performance', 'mobile'],
   processPage: function (page, domAdvice, options) {
     let sizeLimit = options.mobile ? 1000000 : 2000000;

--- a/lib/har/performance/privateAssets.js
+++ b/lib/har/performance/privateAssets.js
@@ -21,6 +21,7 @@ module.exports = {
   description:
     'If you set private headers on content, that means that the content are specific for that user. Static content should be able to be cached and used by everyone. Avoid setting the cache header to private.',
   weight: 5,
+  severity: 'warn',
   tags: ['performance', 'server'],
   processPage: function (page) {
     let advice = '';

--- a/lib/har/performance/responseOk.js
+++ b/lib/har/performance/responseOk.js
@@ -6,6 +6,7 @@ module.exports = {
   description:
     'Your page should never request assets that return a 400 or 500 error. These requests are never cached. If that happens something is broken. Please fix it.',
   weight: 7,
+  severity: 'error',
   tags: ['performance', 'server'],
 
   processPage: function (page) {

--- a/lib/har/privacy/contentSecurityPolicyHeader.js
+++ b/lib/har/privacy/contentSecurityPolicyHeader.js
@@ -7,6 +7,7 @@ module.exports = {
   description:
     'Content Security Policy is delivered via a HTTP response header, and defines approved sources of content that the browser may load. It can be an effective countermeasure to Cross Site Scripting (XSS) attacks and is also widely supported and usually easily deployed. https://scotthelme.co.uk/content-security-policy-an-introduction/.',
   weight: 5,
+  severity: 'warn',
   tags: ['privacy', 'bestpractice', 'headers'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/googleReCaptcha.js
+++ b/lib/har/privacy/googleReCaptcha.js
@@ -5,6 +5,7 @@ module.exports = {
   description:
     'You should avoid using Google reCAPTCHA since it will share your users information with Google.',
   weight: 9,
+  severity: 'warn',
   tags: ['privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/mixedContent.js
+++ b/lib/har/privacy/mixedContent.js
@@ -6,6 +6,7 @@ module.exports = {
   description:
     'You need to make sure that if you are on HTTPS, all responses are on HTTPS so that the content served are secured.',
   weight: 7,
+  severity: 'error',
   tags: ['privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/permissionsPolicyHeader.js
+++ b/lib/har/privacy/permissionsPolicyHeader.js
@@ -7,6 +7,7 @@ module.exports = {
   description:
     'The Permissions-Policy response header (the successor to Feature-Policy) lets a site explicitly opt in or out of powerful browser features such as camera, microphone, geolocation, payment and clipboard. Setting a strict policy reduces the attack surface and limits what embedded third parties can do. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy',
   weight: 4,
+  severity: 'warn',
   tags: ['headers', 'privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/referrerPolicyHeader.js
+++ b/lib/har/privacy/referrerPolicyHeader.js
@@ -7,6 +7,7 @@ module.exports = {
   description:
     'Referrer Policy is a new header that allows a site to control how much information the browser includes with navigations away from a document and should be set by all sites. https://scotthelme.co.uk/a-new-security-header-referrer-policy/.',
   weight: 6,
+  severity: 'warn',
   tags: ['headers', 'privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/strictTransportSecurityHeader.js
+++ b/lib/har/privacy/strictTransportSecurityHeader.js
@@ -7,6 +7,7 @@ module.exports = {
   description:
     'The HTTP Strict-Transport-Security response header (often abbreviated as HSTS) lets a web site tell browsers that it should only be accessed using HTTPS, instead of using HTTP. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security.',
   weight: 6,
+  severity: 'error',
   tags: ['headers', 'privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/thirdPartyCookies.js
+++ b/lib/har/privacy/thirdPartyCookies.js
@@ -6,6 +6,7 @@ module.exports = {
   description:
     'Third party cookies are used to track the user. They are automatically blocked in Safari and Firefox.',
   weight: 6,
+  severity: 'warn',
   tags: ['cookies', 'privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/thirdPartyPrivacy.js
+++ b/lib/har/privacy/thirdPartyPrivacy.js
@@ -9,6 +9,7 @@ module.exports = {
   description:
     'Using third party requests shares user information with that third party. Please avoid that! The project https://github.com/patrickhulce/third-party-web is used to categorize first/third party requests.',
   weight: 5,
+  severity: 'info',
   tags: ['privacy'],
   processPage: function (page) {
     const thirdParties = thirdParty.getThirdParty(page);

--- a/lib/har/privacy/xContentTypeOptionsHeader.js
+++ b/lib/har/privacy/xContentTypeOptionsHeader.js
@@ -7,6 +7,7 @@ module.exports = {
   description:
     'X-Content-Type-Options: nosniff prevents browsers from interpreting files as a different MIME type than what is declared in the Content-Type header. This blocks a class of cross-site scripting and content-type confusion attacks and should be set on every response. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options',
   weight: 4,
+  severity: 'warn',
   tags: ['headers', 'privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const merge = require('lodash.merge');
+const severity = require('./severity');
 
 function recalculateScore(results) {
   var totalScore = 0,
@@ -15,6 +16,13 @@ function recalculateScore(results) {
     if (adviceList) {
       Object.keys(adviceList).forEach((adviceName) => {
         var advice = adviceList[adviceName];
+
+        // Backfill severity on any rule that didn't declare one. This covers
+        // older or plugin-supplied DOM rules whose IIFE return doesn't yet
+        // include the field. The HAR runner already applies the same default.
+        if (!advice.severity) {
+          advice.severity = severity.fromWeight(advice.weight);
+        }
 
         totalScore += advice.score * advice.weight;
         categoryScore += advice.score * advice.weight;

--- a/lib/severity.js
+++ b/lib/severity.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// Three-tier severity classification, modelled on Lighthouse / axe-core:
+//   error = security hole, broken page, or broken Core Web Vital
+//   warn  = noticeable issue users or tools should act on
+//   info  = advisory / informational, depends on context
+//
+// Severity is intentionally orthogonal to weight. Weight controls how
+// strongly a rule pulls on the aggregate score; severity tells a consumer
+// how loudly to surface a finding regardless of weight. A high-weight
+// performance hint and a low-weight security hole can have the same score
+// impact but very different severities, and that distinction is what this
+// field exists to capture.
+const ERROR = 'error';
+const WARN = 'warn';
+const INFO = 'info';
+
+// Fallback used by the runner and the merger for rules that haven't yet
+// declared an explicit severity (older rules, plugin-supplied rules, etc).
+// Newer rules should declare `severity` directly so the value reflects
+// editorial intent, not an arithmetic guess from weight.
+function fromWeight(weight) {
+  if (typeof weight !== 'number') {
+    return WARN;
+  }
+  if (weight >= 8) {
+    return ERROR;
+  }
+  if (weight >= 4) {
+    return WARN;
+  }
+  return INFO;
+}
+
+module.exports = { ERROR, WARN, INFO, fromWeight };

--- a/test/merge/severityTest.js
+++ b/test/merge/severityTest.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const assert = require('assert');
+const merge = require('../../lib/merge').merge;
+const severity = require('../../lib/severity');
+
+const domResult = require('./files/domResult.json');
+const harResult = require('./files/harResult.json');
+
+describe('Severity tier', function () {
+  describe('fromWeight fallback', function () {
+    it('classifies weight >= 8 as error', function () {
+      assert.strictEqual(severity.fromWeight(8), 'error');
+      assert.strictEqual(severity.fromWeight(10), 'error');
+    });
+
+    it('classifies weight 4..7 as warn', function () {
+      assert.strictEqual(severity.fromWeight(4), 'warn');
+      assert.strictEqual(severity.fromWeight(7), 'warn');
+    });
+
+    it('classifies weight < 4 as info', function () {
+      assert.strictEqual(severity.fromWeight(0), 'info');
+      assert.strictEqual(severity.fromWeight(3), 'info');
+    });
+
+    it('falls back to warn for non-numeric weight', function () {
+      assert.strictEqual(severity.fromWeight(undefined), 'warn');
+      assert.strictEqual(severity.fromWeight(null), 'warn');
+    });
+  });
+
+  describe('merge backfill', function () {
+    it('every advice in the merged result has a severity', function () {
+      const result = merge(domResult, harResult);
+      Object.keys(result.advice).forEach(function (categoryName) {
+        const category = result.advice[categoryName];
+        if (!category || !category.adviceList) {
+          return;
+        }
+        Object.keys(category.adviceList).forEach(function (adviceName) {
+          const advice = category.adviceList[adviceName];
+          assert.ok(
+            advice.severity === 'error' ||
+              advice.severity === 'warn' ||
+              advice.severity === 'info',
+            `expected severity on ${categoryName}.${adviceName}, got ${advice.severity}`
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
  The weighted-score model gives every finding a number, but it can't say whether a finding is a security hole, a
  noticeable issue, or just an advisory note. So a missing CSP header (warn) and a print stylesheet (info) used to look
   the same to a consumer that only had score and weight to work with.

  This change introduces a severity field on every rule with three levels modelled on Lighthouse and axe — error / warn
   / info. Severity is intentionally orthogonal to weight: weight controls how strongly a rule pulls on the aggregate
  score, severity tells a UI or filter how loudly to surface the finding. A high-weight perf hint and a low-weight
  security hole can have the same score impact and very different severities.

  The HAR runner already threads severity through to results, the merger backfills any advice that lacks the field
  (covering DOM rules without an explicit declaration as well as plugin-supplied rules), and every rule that ships with
   the package now declares its own severity. The default-from-weight fallback exists for forward compat, but it
  deliberately does not drive the editorial picks — those are made per rule. Existing score and weight values, the
  recalculateScore math, and the public result shape are unchanged apart from the additive new field.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com