### PR TITLE
Migrate the package to ECMAScript Modules

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -24,8 +24,8 @@ module.exports = [
         ...globals.node
       },
 
-      ecmaVersion: 2018,
-      sourceType: 'commonjs'
+      ecmaVersion: 'latest',
+      sourceType: 'module'
     },
 
     rules: {
@@ -45,9 +45,19 @@ module.exports = [
   {
     files: ['lib/dom/**'],
     languageOptions: {
+      sourceType: 'script',
       globals: {
         ...globals.browser,
         util: true
+      }
+    }
+  },
+  {
+    // util.js itself declares util locally, so don't treat it as a global there.
+    files: ['lib/dom/util.js'],
+    languageOptions: {
+      globals: {
+        util: 'off'
       }
     }
   }

--- a/lib/har/bestpractice/longHeaders.js
+++ b/lib/har/bestpractice/longHeaders.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-const util = require('../util');
-
-module.exports = {
+export default {
   id: 'longHeaders',
   title: 'Do not send too long headers',
   description: 'Do not send response headers that are too long.',

--- a/lib/har/bestpractice/manyHeaders.js
+++ b/lib/har/bestpractice/manyHeaders.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-const util = require('../util');
-
-module.exports = {
+export default {
   id: 'manyHeaders',
   title: 'Avoid use too many response headers',
   description: 'Avoid send too many response headers.',

--- a/lib/har/bestpractice/thirdParty.js
+++ b/lib/har/bestpractice/thirdParty.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-const util = require('../util');
-
-module.exports = {
+export default {
   id: 'thirdParty',
   title: 'Avoid too many third party requests',
   description: 'Do not load most of your content from third party URLs.',

--- a/lib/har/bestpractice/unnecessaryHeaders.js
+++ b/lib/har/bestpractice/unnecessaryHeaders.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-const util = require('../util');
-
-module.exports = {
+export default {
   id: 'unnecessaryHeaders',
   title: 'Avoid unnecessary headers',
   description:

--- a/lib/har/harCutter.js
+++ b/lib/har/harCutter.js
@@ -1,8 +1,6 @@
-'use strict';
+import groupBy from 'lodash.groupby';
 
-var groupBy = require('lodash.groupby');
-
-module.exports.pickAPage = function (har, pageIndex) {
+export function pickAPage(har, pageIndex) {
   if (typeof har.log.pages[pageIndex] !== 'undefined') {
     const myHar = JSON.parse(JSON.stringify(har));
 
@@ -17,4 +15,4 @@ module.exports.pickAPage = function (har, pageIndex) {
   } else {
     throw new Error('PageIndex out of range');
   }
-};
+}

--- a/lib/har/index.js
+++ b/lib/har/index.js
@@ -1,16 +1,12 @@
-'use strict';
+import { createRequire } from 'node:module';
+import * as util from './util.js';
+import * as thirdParty from './thirdParty.js';
+import * as severity from '../severity.js';
 
-const util = require('./util');
-const packageInfo = require('../../package');
-const thirdParty = require('./thirdParty');
-const severity = require('../severity');
+const require = createRequire(import.meta.url);
+const packageInfo = require('../../package.json');
 
-module.exports.runAdvice = function (
-  pages,
-  harAdvicesByCategory,
-  domAdvice,
-  options
-) {
+export function runAdvice(pages, harAdvicesByCategory, domAdvice, options) {
   options = options || {};
   const all = [];
   const results = {};
@@ -80,7 +76,7 @@ module.exports.runAdvice = function (
     all.push(withoutCategories);
   }
   return all;
-};
+}
 
 function validateAdvice(advice) {
   if (!advice.id) {

--- a/lib/har/info/technology.js
+++ b/lib/har/info/technology.js
@@ -1,28 +1,14 @@
-'use strict';
-const fs = require('fs');
-const path = require('path');
-const Wappalyzer = require('wappalyzer-core');
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Wappalyzer from 'wappalyzer-core';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const categories = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, './../categories.json'))
+  readFileSync(resolve(__dirname, './../categories.json'))
 );
 
-/*
-let technologies = {}
-
-for (const index of Array(27).keys()) {
-  const character = index ? String.fromCharCode(index + 96) : '_'
-
-  technologies = {
-    ...technologies,
-    ...JSON.parse(
-      fs.readFileSync(
-        path.resolve(`${__dirname}./../technologies/${character}.json`)
-      )
-    ),
-  }
-}
-*/
 // Initialize an empty object to store technologies
 let technologies = {};
 
@@ -34,11 +20,9 @@ for (const index of Array(arrayLength).keys()) {
   // If index is 0, use '_', else use ASCII character corresponding to (index + 96)
   const character = index ? String.fromCharCode(index + 96) : '_';
 
-  const filePath = path.resolve(
-    `${__dirname}/../../technologies/${character}.json`
-  );
+  const filePath = resolve(`${__dirname}/../../technologies/${character}.json`);
 
-  const fileContent = fs.readFileSync(filePath);
+  const fileContent = readFileSync(filePath);
   const technologiesToAdd = JSON.parse(fileContent);
 
   // Merge the parsed content into our technologies object
@@ -51,7 +35,7 @@ for (const index of Array(arrayLength).keys()) {
 Wappalyzer.setTechnologies(technologies);
 Wappalyzer.setCategories(categories);
 
-module.exports = {
+export default {
   id: 'technology',
   processPage: function (page) {
     let headers = {},

--- a/lib/har/info/thirdParty.js
+++ b/lib/har/info/thirdParty.js
@@ -1,7 +1,6 @@
-'use strict';
-const thirdParty = require('../thirdParty');
+import * as thirdParty from '../thirdParty.js';
 
-module.exports = {
+export default {
   id: 'thirdparty',
   processPage: function (page) {
     const thirdParties = thirdParty.getThirdParty(page);

--- a/lib/har/performance/assetsRedirects.js
+++ b/lib/har/performance/assetsRedirects.js
@@ -1,6 +1,4 @@
-'use strict';
-
-let util = require('../util');
+import * as util from '../util.js';
 
 var redirect = [301, 302, 303, 305, 306, 307];
 
@@ -8,7 +6,7 @@ function isRedirect(asset) {
   return redirect.indexOf(asset.status) > -1;
 }
 
-module.exports = {
+export default {
   id: 'assetsRedirects',
   title: 'Avoid doing redirects',
   description:

--- a/lib/har/performance/avoidRenderBlocking.js
+++ b/lib/har/performance/avoidRenderBlocking.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'avoidRenderBlocking',
   title: 'Avoid slowing down the critical rendering path',
   description:

--- a/lib/har/performance/cacheHeaders.js
+++ b/lib/har/performance/cacheHeaders.js
@@ -1,6 +1,4 @@
-'use strict';
-
-let util = require('../util');
+import * as util from '../util.js';
 
 const SKIPPABLE_DOMAINS = [
   'www.google-analytics.com',
@@ -8,7 +6,7 @@ const SKIPPABLE_DOMAINS = [
   'analytics.twitter.com'
 ];
 
-module.exports = {
+export default {
   id: 'cacheHeaders',
   title: 'Avoid extra requests by setting cache headers',
   description:

--- a/lib/har/performance/cacheHeadersLong.js
+++ b/lib/har/performance/cacheHeadersLong.js
@@ -1,6 +1,4 @@
-'use strict';
-
-let util = require('../util');
+import * as util from '../util.js';
 
 const SKIPPABLE_DOMAINS = [
   'www.google-analytics.com',
@@ -22,7 +20,7 @@ function processAsset(asset) {
   }
 }
 
-module.exports = {
+export default {
   id: 'cacheHeadersLong',
   title: 'Long cache headers is good',
   description:

--- a/lib/har/performance/compressAssets.js
+++ b/lib/har/performance/compressAssets.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const util = require('../util');
+import * as util from '../util.js';
 const types = ['html', 'plain', 'json', 'javascript', 'css', 'svg'];
 
 function processAsset(asset) {
@@ -22,7 +20,7 @@ function processAsset(asset) {
   return 0;
 }
 
-module.exports = {
+export default {
   id: 'compressAssets',
   title: 'Always compress text content',
   description:

--- a/lib/har/performance/connectionKeepAlive.js
+++ b/lib/har/performance/connectionKeepAlive.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-const util = require('../util');
-
-module.exports = {
+export default {
   id: 'connectionKeepAlive',
   title: "Don't close a connection that is used multiple times",
   description:

--- a/lib/har/performance/cpuTimeSpentInRendering.js
+++ b/lib/har/performance/cpuTimeSpentInRendering.js
@@ -1,5 +1,4 @@
-'use strict';
-module.exports = {
+export default {
   id: 'cpuTimeSpentInRendering',
   title: 'Avoid spend too much CPU time to render the page',
   description:

--- a/lib/har/performance/cpuTimeSpentInScripting.js
+++ b/lib/har/performance/cpuTimeSpentInScripting.js
@@ -1,5 +1,4 @@
-'use strict';
-module.exports = {
+export default {
   id: 'cpuTimeSpentInScripting',
   title: 'Avoid executing too much JavaScript',
   description:

--- a/lib/har/performance/cssSize.js
+++ b/lib/har/performance/cssSize.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-let util = require('../util');
-
-module.exports = {
+export default {
   id: 'cssSize',
   title: "Total CSS size shouldn't be too big",
   description:

--- a/lib/har/performance/documentRedirect.js
+++ b/lib/har/performance/documentRedirect.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'documentRedirect',
   title: 'Avoid redirecting the main document',
   description:

--- a/lib/har/performance/favicon.js
+++ b/lib/har/performance/favicon.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-const util = require('../util');
-
-module.exports = {
+export default {
   id: 'favicon',
   title: 'The favicon should be small and cacheable',
   description:

--- a/lib/har/performance/fewFonts.js
+++ b/lib/har/performance/fewFonts.js
@@ -1,7 +1,6 @@
-'use strict';
-const util = require('../util');
+import * as util from '../util.js';
 
-module.exports = {
+export default {
   id: 'fewFonts',
   title: 'Avoid too many fonts',
   description:

--- a/lib/har/performance/fewRequestsPerDomain.js
+++ b/lib/har/performance/fewRequestsPerDomain.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-let util = require('../util');
-
-module.exports = {
+export default {
   id: 'fewRequestsPerDomain',
   title: 'Avoid too many requests per domain [HTTP/1]',
   description:

--- a/lib/har/performance/headerSize.js
+++ b/lib/har/performance/headerSize.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-let util = require('../util');
-
-module.exports = {
+export default {
   id: 'headerSize',
   title: "Response headers should't be too big [HTTP/1]",
   description:

--- a/lib/har/performance/imageSize.js
+++ b/lib/har/performance/imageSize.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-let util = require('../util');
-
-module.exports = {
+export default {
   id: 'imageSize',
   title: "Total image size shouldn't be too big",
   description:

--- a/lib/har/performance/javascriptSize.js
+++ b/lib/har/performance/javascriptSize.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-let util = require('../util');
-
-module.exports = {
+export default {
   id: 'javascriptSize',
   title: "Total JavaScript size shouldn't be too big",
   description:

--- a/lib/har/performance/mimeTypes.js
+++ b/lib/har/performance/mimeTypes.js
@@ -1,7 +1,6 @@
-'use strict';
-const util = require('../util');
+import * as util from '../util.js';
 
-module.exports = {
+export default {
   id: 'mimeTypes',
   title: 'Avoid using incorrect mime types',
   description:

--- a/lib/har/performance/optimalCssSize.js
+++ b/lib/har/performance/optimalCssSize.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-let util = require('../util');
-
-module.exports = {
+export default {
   id: 'optimalCssSize',
   title: 'Make each CSS response small',
   description:

--- a/lib/har/performance/pageSize.js
+++ b/lib/har/performance/pageSize.js
@@ -1,8 +1,6 @@
-'use strict';
+import * as util from '../util.js';
 
-let util = require('../util');
-
-module.exports = {
+export default {
   id: 'pageSize',
   title: "Total page size shouldn't be too big",
   description:

--- a/lib/har/performance/privateAssets.js
+++ b/lib/har/performance/privateAssets.js
@@ -1,5 +1,4 @@
-'use strict';
-const util = require('../util');
+import * as util from '../util.js';
 const types = ['json', 'javascript', 'css', 'image', 'svg', 'font', 'html'];
 
 function processAsset(asset) {
@@ -15,7 +14,7 @@ function processAsset(asset) {
   return 0;
 }
 
-module.exports = {
+export default {
   id: 'privateAssets',
   title: "Don't use private headers on static content",
   description:

--- a/lib/har/performance/responseOk.js
+++ b/lib/har/performance/responseOk.js
@@ -1,6 +1,5 @@
-'use strict';
-const util = require('../util');
-module.exports = {
+import * as util from '../util.js';
+export default {
   id: 'responseOk',
   title: 'Avoid missing and error requests',
   description:

--- a/lib/har/privacy/contentSecurityPolicyHeader.js
+++ b/lib/har/privacy/contentSecurityPolicyHeader.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'contentSecurityPolicyHeader',
   title:
     'Use a good Content-Security-Policy header to make sure you you avoid Cross Site Scripting (XSS) attacks.',

--- a/lib/har/privacy/crossOriginEmbedderPolicyHeader.js
+++ b/lib/har/privacy/crossOriginEmbedderPolicyHeader.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'crossOriginEmbedderPolicyHeader',
   title:
     'Set a Cross-Origin-Embedder-Policy header so cross-origin subresources opt in to being embedded.',

--- a/lib/har/privacy/crossOriginOpenerPolicyHeader.js
+++ b/lib/har/privacy/crossOriginOpenerPolicyHeader.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'crossOriginOpenerPolicyHeader',
   title:
     'Set a Cross-Origin-Opener-Policy header to isolate the page from cross-origin windows.',

--- a/lib/har/privacy/crossOriginResourcePolicyHeader.js
+++ b/lib/har/privacy/crossOriginResourcePolicyHeader.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'crossOriginResourcePolicyHeader',
   title:
     'Set a Cross-Origin-Resource-Policy header to limit who may embed the page.',

--- a/lib/har/privacy/googleReCaptcha.js
+++ b/lib/har/privacy/googleReCaptcha.js
@@ -1,5 +1,4 @@
-'use strict';
-module.exports = {
+export default {
   id: 'googleReCaptcha',
   title: 'Avoid using Google reCAPTCHA',
   description:

--- a/lib/har/privacy/mixedContent.js
+++ b/lib/har/privacy/mixedContent.js
@@ -1,6 +1,5 @@
-'use strict';
-const util = require('../util');
-module.exports = {
+import * as util from '../util.js';
+export default {
   id: 'mixedContent',
   title: 'Serve all responses on HTTPS (when you are on HTTPS)',
   description:

--- a/lib/har/privacy/permissionsPolicyHeader.js
+++ b/lib/har/privacy/permissionsPolicyHeader.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'permissionsPolicyHeader',
   title:
     'Set a Permissions-Policy header to control which browser features the page can use.',

--- a/lib/har/privacy/referrerPolicyHeader.js
+++ b/lib/har/privacy/referrerPolicyHeader.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'referrerPolicyHeader',
   title:
     'Set a referrer-policy header to make sure you do not leak user information.',

--- a/lib/har/privacy/strictTransportSecurityHeader.js
+++ b/lib/har/privacy/strictTransportSecurityHeader.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'strictTransportSecurityHeader',
   title:
     'Set a strict transport header to make sure the user always use HTTPS.',

--- a/lib/har/privacy/thirdPartyCookies.js
+++ b/lib/har/privacy/thirdPartyCookies.js
@@ -1,6 +1,5 @@
-'use strict';
-const util = require('../util');
-module.exports = {
+import * as util from '../util.js';
+export default {
   id: 'thirdPartyCookies',
   title: 'Avoid third party cookies that is used to track the user.',
   description:

--- a/lib/har/privacy/thirdPartyPrivacy.js
+++ b/lib/har/privacy/thirdPartyPrivacy.js
@@ -1,9 +1,7 @@
-'use strict';
+import * as util from '../util.js';
+import * as thirdParty from '../thirdParty.js';
 
-const util = require('../util');
-const thirdParty = require('../thirdParty');
-
-module.exports = {
+export default {
   id: 'thirdPartyPrivacy',
   title: 'Do not share user data with third parties.',
   description:

--- a/lib/har/privacy/xContentTypeOptionsHeader.js
+++ b/lib/har/privacy/xContentTypeOptionsHeader.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = {
+export default {
   id: 'xContentTypeOptionsHeader',
   title:
     'Set X-Content-Type-Options: nosniff to stop the browser from MIME-sniffing the response.',

--- a/lib/har/thirdParty.js
+++ b/lib/har/thirdParty.js
@@ -1,8 +1,8 @@
-'use strict';
+import thirdPartyWeb from 'third-party-web';
 
-const { getEntity } = require('third-party-web');
+const { getEntity } = thirdPartyWeb;
 
-module.exports.getThirdParty = function (page) {
+export function getThirdParty(page) {
   const toolsByCategory = {};
   const offending = [];
   const byCategory = {};
@@ -87,4 +87,4 @@ module.exports.getThirdParty = function (page) {
     byCategory,
     offending
   };
-};
+}

--- a/lib/har/util.js
+++ b/lib/har/util.js
@@ -1,125 +1,128 @@
-'use strict';
+import urlParser from 'node:url';
 
-const urlParser = require('url');
+export function isHTTP2(page) {
+  return page.httpType === 'h2';
+}
 
-module.exports = {
-  isHTTP2(page) {
-    return page.httpType === 'h2';
-  },
-  isHTTP3(page) {
-    return page.httpType.startsWith('h3');
-  },
-  /**
-   * Get the hostname from a URL string.
-   * @param {string} url The URL like https://www.example.com/hepp
-   * @returns {string} the hostname
-   */
-  getHostname(url) {
-    if (!url) {
-      return '';
-    }
+export function isHTTP3(page) {
+  return page.httpType.startsWith('h3');
+}
 
-    return urlParser.parse(url).hostname || '';
-  },
-  /**
-   * Convert bytes to human readable.
-   * @param {Number} bytes
-   * @returns {String} human readable file size
-   */
-  formatBytes(bytes) {
-    var sizes = ['B', 'kB', 'MB', 'GB', 'TB'];
-
-    if (bytes === 0) {
-      return '0 B';
-    }
-
-    var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1000)), 10);
-    return Math.round((bytes / Math.pow(1000, i)) * 10) / 10 + ' ' + sizes[i];
-  },
-  /**
-   * Print seconds as the largest available time.
-   * @param {int} seconds A number in seconds
-   * @return {String} The time in nearest largest definition.
-   */
-  prettyPrintSeconds: function (seconds) {
-    if (typeof seconds === 'undefined') {
-      return '';
-    }
-
-    var secondsPerYear = 365 * 24 * 60 * 60,
-      secondsPerWeek = 60 * 60 * 24 * 7,
-      secondsPerDay = 60 * 60 * 24,
-      secondsPerHour = 60 * 60,
-      secondsPerMinute = 60,
-      sign = seconds < 0 ? '-' : '';
-
-    if (seconds < 0) {
-      seconds = Math.abs(seconds);
-    }
-
-    if (seconds / secondsPerYear >= 1) {
-      return (
-        sign +
-        Math.round(seconds / secondsPerYear) +
-        ' year' +
-        (Math.round(seconds / secondsPerYear) > 1 ? 's' : '')
-      );
-    } else if (seconds / secondsPerWeek >= 1) {
-      return (
-        sign +
-        Math.round(seconds / secondsPerWeek) +
-        ' week' +
-        (Math.round(seconds / secondsPerWeek) > 1 ? 's' : '')
-      );
-    } else if (seconds / secondsPerDay >= 1) {
-      return (
-        sign +
-        Math.round(seconds / secondsPerDay) +
-        ' day' +
-        (Math.round(seconds / secondsPerDay) > 1 ? 's' : '')
-      );
-    } else if (seconds / secondsPerHour >= 1) {
-      return (
-        sign +
-        Math.round(seconds / secondsPerHour) +
-        ' hour' +
-        (Math.round(seconds / secondsPerHour) > 1 ? 's' : '')
-      );
-    } else if (seconds / secondsPerMinute >= 1) {
-      return (
-        sign +
-        Math.round(seconds / secondsPerMinute) +
-        ' minute' +
-        (Math.round(seconds / secondsPerMinute) > 1 ? 's' : '')
-      );
-    } else {
-      return (
-        sign + seconds + ' second' + (seconds > 1 || seconds === 0 ? 's' : '')
-      );
-    }
-  },
-  human(node, pretty) {
-    if (!node) {
-      return undefined;
-    }
-
-    let clean = {};
-    Object.keys(node).forEach(function (key) {
-      clean[key] = pretty(node[key]);
-    });
-    return clean;
-  },
-  shortURL(url) {
-    if (url.length > 40) {
-      let shortUrl = url.replace(/\?.*/, '');
-      url = shortUrl.substr(0, 20) + '...' + shortUrl.substr(-17);
-    }
-    return url;
-  },
-  plural: function (number, text) {
-    if (number > 1) {
-      text += 's';
-    }
-    return `${number} ${text}`;
+/**
+ * Get the hostname from a URL string.
+ * @param {string} url The URL like https://www.example.com/hepp
+ * @returns {string} the hostname
+ */
+export function getHostname(url) {
+  if (!url) {
+    return '';
   }
-};
+
+  return urlParser.parse(url).hostname || '';
+}
+
+/**
+ * Convert bytes to human readable.
+ * @param {Number} bytes
+ * @returns {String} human readable file size
+ */
+export function formatBytes(bytes) {
+  var sizes = ['B', 'kB', 'MB', 'GB', 'TB'];
+
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1000)), 10);
+  return Math.round((bytes / Math.pow(1000, i)) * 10) / 10 + ' ' + sizes[i];
+}
+
+/**
+ * Print seconds as the largest available time.
+ * @param {int} seconds A number in seconds
+ * @return {String} The time in nearest largest definition.
+ */
+export function prettyPrintSeconds(seconds) {
+  if (typeof seconds === 'undefined') {
+    return '';
+  }
+
+  var secondsPerYear = 365 * 24 * 60 * 60,
+    secondsPerWeek = 60 * 60 * 24 * 7,
+    secondsPerDay = 60 * 60 * 24,
+    secondsPerHour = 60 * 60,
+    secondsPerMinute = 60,
+    sign = seconds < 0 ? '-' : '';
+
+  if (seconds < 0) {
+    seconds = Math.abs(seconds);
+  }
+
+  if (seconds / secondsPerYear >= 1) {
+    return (
+      sign +
+      Math.round(seconds / secondsPerYear) +
+      ' year' +
+      (Math.round(seconds / secondsPerYear) > 1 ? 's' : '')
+    );
+  } else if (seconds / secondsPerWeek >= 1) {
+    return (
+      sign +
+      Math.round(seconds / secondsPerWeek) +
+      ' week' +
+      (Math.round(seconds / secondsPerWeek) > 1 ? 's' : '')
+    );
+  } else if (seconds / secondsPerDay >= 1) {
+    return (
+      sign +
+      Math.round(seconds / secondsPerDay) +
+      ' day' +
+      (Math.round(seconds / secondsPerDay) > 1 ? 's' : '')
+    );
+  } else if (seconds / secondsPerHour >= 1) {
+    return (
+      sign +
+      Math.round(seconds / secondsPerHour) +
+      ' hour' +
+      (Math.round(seconds / secondsPerHour) > 1 ? 's' : '')
+    );
+  } else if (seconds / secondsPerMinute >= 1) {
+    return (
+      sign +
+      Math.round(seconds / secondsPerMinute) +
+      ' minute' +
+      (Math.round(seconds / secondsPerMinute) > 1 ? 's' : '')
+    );
+  } else {
+    return (
+      sign + seconds + ' second' + (seconds > 1 || seconds === 0 ? 's' : '')
+    );
+  }
+}
+
+export function human(node, pretty) {
+  if (!node) {
+    return undefined;
+  }
+
+  let clean = {};
+  Object.keys(node).forEach(function (key) {
+    clean[key] = pretty(node[key]);
+  });
+  return clean;
+}
+
+export function shortURL(url) {
+  if (url.length > 40) {
+    let shortUrl = url.replace(/\?.*/, '');
+    url = shortUrl.substr(0, 20) + '...' + shortUrl.substr(-17);
+  }
+  return url;
+}
+
+export function plural(number, text) {
+  if (number > 1) {
+    text += 's';
+  }
+  return `${number} ${text}`;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,16 @@
-'use strict';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import pagexray from 'pagexray';
+import thirdPartyWeb from 'third-party-web';
+import lodashMerge from 'lodash.merge';
+import { merge as merger } from './merge.js';
+import { pickAPage as pickAPageImpl } from './har/harCutter.js';
+import { runAdvice } from './har/index.js';
 
-const fs = require('fs');
-const pagexray = require('pagexray');
-const path = require('path');
-const thirdPartyWeb = require('third-party-web');
-const merger = require('./merge').merge;
-const merge = require('lodash.merge');
-const pickAPage = require('./har/harCutter').pickAPage;
-const harRunner = require('./har');
-const { promisify } = require('util');
-const readFile = promisify(fs.readFile);
-const stat = promisify(fs.stat);
-const readdir = promisify(fs.readdir);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 const packageJSON = require('../package.json');
 const technologiesVersion = require('./technologies/VERSION.json');
 
@@ -22,82 +21,96 @@ function getPagesFromHar(harJson, options) {
   });
 }
 
-module.exports = {
-  async getDomAdvice() {
-    return readFile(
-      path.resolve(__dirname, '..', 'dist', 'coach.min.js'),
-      'utf8'
-    );
-  },
-  async getHarAdvice() {
-    // The folder structure looks something like this
-    // har/
-    // har/bestpractice/advice.js
-    // har/performance/advice.js
-    // files.js
-    const harRootPath = path.resolve(__dirname, 'har');
+export async function getDomAdvice() {
+  return readFile(resolve(__dirname, '..', 'dist', 'coach.min.js'), 'utf8');
+}
 
-    async function getFolders(path) {
-      const result = [];
-      const files = await readdir(path);
-      for (let file of files) {
-        const filePath = path + '/' + file;
-        if ((await stat(filePath)).isDirectory()) {
-          result.push(file);
-        }
-      }
-      return result;
-    }
+export async function getHarAdvice() {
+  // The folder structure looks something like this
+  // har/
+  // har/bestpractice/advice.js
+  // har/performance/advice.js
+  // files.js
+  const harRootPath = resolve(__dirname, 'har');
 
-    let folders = await readdir(harRootPath);
-    // We are only interested in folders
-    folders = await getFolders(harRootPath);
-    const harAdvice = {};
-    for (let folderName of folders) {
-      harAdvice[folderName] = [];
-      const categoryPath = path.resolve(__dirname, 'har', folderName);
-      const files = await readdir(categoryPath);
-      for (let fileName of files) {
-        harAdvice[folderName].push(
-          require(path.resolve(categoryPath, fileName))
-        );
+  async function getFolders(rootPath) {
+    const result = [];
+    const files = await readdir(rootPath);
+    for (let file of files) {
+      const filePath = rootPath + '/' + file;
+      if ((await stat(filePath)).isDirectory()) {
+        result.push(file);
       }
     }
-    return harAdvice;
-  },
-
-  async analyseHar(har, harAdvice, domAdviceResult, options) {
-    if (!harAdvice) {
-      harAdvice = await module.exports.getHarAdvice();
-    }
-
-    options = merge({}, options);
-    return harRunner.runAdvice(
-      getPagesFromHar(har, options),
-      harAdvice,
-      domAdviceResult,
-      options
-    );
-  },
-  merge(domAdviceResult, harAdviceResult) {
-    return merger(domAdviceResult, harAdviceResult);
-  },
-  pickAPage(har, pageIndex) {
-    return pickAPage(har, pageIndex);
-  },
-  getThirdPartyWeb() {
-    return thirdPartyWeb;
-  },
-  getPageXray() {
-    return pagexray;
-  },
-  getThirdPartyWebVersion() {
-    return packageJSON.dependencies['third-party-web'];
-  },
-  getWappalyzerCoreVersion() {
-    return packageJSON.dependencies['wappalyzer-core'];
-  },
-  getTechnologiesVersion() {
-    return technologiesVersion;
+    return result;
   }
+
+  const folders = await getFolders(harRootPath);
+  const harAdvice = {};
+  for (let folderName of folders) {
+    harAdvice[folderName] = [];
+    const categoryPath = resolve(__dirname, 'har', folderName);
+    const files = await readdir(categoryPath);
+    for (let fileName of files) {
+      const moduleUrl = pathToFileURL(resolve(categoryPath, fileName)).href;
+      const mod = await import(moduleUrl);
+      harAdvice[folderName].push(mod.default);
+    }
+  }
+  return harAdvice;
+}
+
+export async function analyseHar(har, harAdvice, domAdviceResult, options) {
+  if (!harAdvice) {
+    harAdvice = await getHarAdvice();
+  }
+
+  options = lodashMerge({}, options);
+  return runAdvice(
+    getPagesFromHar(har, options),
+    harAdvice,
+    domAdviceResult,
+    options
+  );
+}
+
+export function merge(domAdviceResult, harAdviceResult) {
+  return merger(domAdviceResult, harAdviceResult);
+}
+
+export function pickAPage(har, pageIndex) {
+  return pickAPageImpl(har, pageIndex);
+}
+
+export function getThirdPartyWeb() {
+  return thirdPartyWeb;
+}
+
+export function getPageXray() {
+  return pagexray;
+}
+
+export function getThirdPartyWebVersion() {
+  return packageJSON.dependencies['third-party-web'];
+}
+
+export function getWappalyzerCoreVersion() {
+  return packageJSON.dependencies['wappalyzer-core'];
+}
+
+export function getTechnologiesVersion() {
+  return technologiesVersion;
+}
+
+export default {
+  getDomAdvice,
+  getHarAdvice,
+  analyseHar,
+  merge,
+  pickAPage,
+  getThirdPartyWeb,
+  getPageXray,
+  getThirdPartyWebVersion,
+  getWappalyzerCoreVersion,
+  getTechnologiesVersion
 };

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,7 +1,5 @@
-'use strict';
-
-const merge = require('lodash.merge');
-const severity = require('./severity');
+import lodashMerge from 'lodash.merge';
+import * as severity from './severity.js';
 
 function recalculateScore(results) {
   var totalScore = 0,
@@ -40,9 +38,7 @@ function recalculateScore(results) {
   return results;
 }
 
-module.exports = {
-  merge(domResult, harResult) {
-    const result = merge(domResult, harResult[0]);
-    return recalculateScore(result);
-  }
-};
+export function merge(domResult, harResult) {
+  const result = lodashMerge(domResult, harResult[0]);
+  return recalculateScore(result);
+}

--- a/lib/severity.js
+++ b/lib/severity.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // Three-tier severity classification, modelled on Lighthouse / axe-core:
 //   error = security hole, broken page, or broken Core Web Vital
 //   warn  = noticeable issue users or tools should act on
@@ -11,15 +9,15 @@
 // performance hint and a low-weight security hole can have the same score
 // impact but very different severities, and that distinction is what this
 // field exists to capture.
-const ERROR = 'error';
-const WARN = 'warn';
-const INFO = 'info';
+export const ERROR = 'error';
+export const WARN = 'warn';
+export const INFO = 'info';
 
 // Fallback used by the runner and the merger for rules that haven't yet
 // declared an explicit severity (older rules, plugin-supplied rules, etc).
 // Newer rules should declare `severity` directly so the value reflects
 // editorial intent, not an arithmetic guess from weight.
-function fromWeight(weight) {
+export function fromWeight(weight) {
   if (typeof weight !== 'number') {
     return WARN;
   }
@@ -31,5 +29,3 @@ function fromWeight(weight) {
   }
   return INFO;
 }
-
-module.exports = { ERROR, WARN, INFO, fromWeight };

--- a/package.json
+++ b/package.json
@@ -11,8 +11,14 @@
     "coach"
   ],
   "main": "./lib/index.js",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./lib/index.js"
+    }
+  },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "lib",

--- a/test/api/domTest.js
+++ b/test/api/domTest.js
@@ -1,10 +1,8 @@
-'use strict';
-
-const api = require('../../lib/'),
-  urlParser = require('url'),
-  webserver = require('../help/webserver'),
-  chai = require('chai'),
-  chaiAsPromised = require('chai-as-promised');
+import api from '../../lib/index.js';
+import urlParser from 'node:url';
+import webserver from '../help/webserver.js';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);
 chai.should();

--- a/test/api/harTest.js
+++ b/test/api/harTest.js
@@ -1,16 +1,14 @@
-'use strict';
+import api from '../../lib/index.js';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { use, should } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
-const api = require('../../lib/'),
-  fs = require('fs'),
-  path = require('path'),
-  Promise = require('bluebird'),
-  chai = require('chai'),
-  chaiAsPromised = require('chai-as-promised');
+use(chaiAsPromised);
+should();
 
-chai.use(chaiAsPromised);
-chai.should();
-
-Promise.promisifyAll(fs);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('HAR APIs:', function() {
   describe('getHarAdvice', function() {
@@ -18,29 +16,33 @@ describe('HAR APIs:', function() {
       api.getHarAdvice().should.eventually.not.be.empty);
 
     it('should only return valid advice', () =>
-      api
-        .getHarAdvice()
-        .then(adviceList =>
-          Promise.each(adviceList.performance, advice =>
-            ['id', 'title', 'description', 'weight', 'tags'].forEach(property =>
-              advice.should.have.ownProperty(property)
-            )
-          )
-        ));
+      api.getHarAdvice().then((adviceList) => {
+        for (const advice of adviceList.performance) {
+          for (const property of [
+            'id',
+            'title',
+            'description',
+            'weight',
+            'tags'
+          ]) {
+            advice.should.have.ownProperty(property);
+          }
+        }
+      }));
   });
 
   describe('analyseHar', async function() {
-    const harPath = path.join(
-        __dirname,
-        '..',
-        'har',
-        'files',
-        'www.nytimes.com.har'
-      ),
-      har = await fs.readFileAsync(harPath, 'utf8').then(JSON.parse);
+    const harPath = join(
+      __dirname,
+      '..',
+      'har',
+      'files',
+      'www.nytimes.com.har'
+    );
+    const har = JSON.parse(await readFile(harPath, 'utf8'));
 
     it('should output correct structure', () =>
-      api.analyseHar(har).then(advicePerPage => {
+      api.analyseHar(har).then((advicePerPage) => {
         advicePerPage.should.have.length(2);
 
         const firstPageAdvice = advicePerPage[0];

--- a/test/api/mergeTest.js
+++ b/test/api/mergeTest.js
@@ -1,11 +1,5 @@
-'use strict';
-
-const api = require('../../lib/'),
-  fs = require('fs'),
-  assert = require('assert'),
-  Promise = require('bluebird');
-
-Promise.promisifyAll(fs);
+import api from '../../lib/index.js';
+import assert from 'node:assert';
 
 describe('Merge API:', function() {
   it('should work', function() {

--- a/test/api/splitTest.js
+++ b/test/api/splitTest.js
@@ -1,27 +1,17 @@
-'use strict';
+import api from '../../lib/index.js';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert';
 
-const api = require('../../lib/'),
-  fs = require('fs'),
-  path = require('path'),
-  Promise = require('bluebird'),
-  assert = require('assert');
-
-Promise.promisifyAll(fs);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('pickAPage HAR API:', function() {
-  const harPath = path.join(
-    __dirname,
-    '..',
-    'har',
-    'files',
-    'www.nytimes.com.har'
-  );
+  const harPath = join(__dirname, '..', 'har', 'files', 'www.nytimes.com.har');
 
-  it('should work', () =>
-    fs
-      .readFileAsync(harPath, 'utf8')
-      .then(JSON.parse)
-      .then(har =>
-        assert.strictEqual(api.pickAPage(har, 0).log.pages.length, 1)
-      ));
+  it('should work', async () => {
+    const text = await readFile(harPath, 'utf8');
+    const har = JSON.parse(text);
+    assert.strictEqual(api.pickAPage(har, 0).log.pages.length, 1);
+  });
 });

--- a/test/dom/adviceTest.js
+++ b/test/dom/adviceTest.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const createTestRunner = require('../help/browsertimeRunner').createTestRunner,
-  assert = require('assert'),
-  fs = require('fs'),
-  path = require('path');
+import { createTestRunner } from '../help/browsertimeRunner.js';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
 
 let ADVICE_CATEGORIES = ['bestpractice', 'performance'];
 

--- a/test/dom/bestpractice/indexTest.js
+++ b/test/dom/bestpractice/indexTest.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Best practice', function() {

--- a/test/dom/combinedTest.js
+++ b/test/dom/combinedTest.js
@@ -1,8 +1,6 @@
-'use strict';
-
-const createTestRunner = require('../help/browsertimeRunner').createTestRunner,
-  path = require('path'),
-  assert = require('assert');
+import { createTestRunner } from '../help/browsertimeRunner.js';
+import path from 'node:path';
+import assert from 'node:assert';
 
 let BROWSERS = ['chrome', 'firefox'];
 

--- a/test/dom/idTest.js
+++ b/test/dom/idTest.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const Promise = require('bluebird'),
-  assert = require('assert'),
-  fs = require('fs'),
-  path = require('path');
+import Promise from 'bluebird';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
 
 Promise.promisifyAll(fs);
 

--- a/test/dom/info/h2Test.js
+++ b/test/dom/info/h2Test.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('info - h2', function() {

--- a/test/dom/info/indexTest.js
+++ b/test/dom/info/indexTest.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Info', function() {

--- a/test/dom/performance/fastRenderH1Test.js
+++ b/test/dom/performance/fastRenderH1Test.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Fast render advice HTTP/1:', function() {

--- a/test/dom/performance/fastRenderH2Test.js
+++ b/test/dom/performance/fastRenderH2Test.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Fast render advice HTTP/2:', function() {

--- a/test/dom/performance/indexTest.js
+++ b/test/dom/performance/indexTest.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Performance advice HTTP/1:', function() {

--- a/test/dom/performance/inlineCssH1Test.js
+++ b/test/dom/performance/inlineCssH1Test.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Inline CSS advice HTTP/1:', function() {

--- a/test/dom/performance/inlineCssH2Test.js
+++ b/test/dom/performance/inlineCssH2Test.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Inline CSS advice HTTP/2:', function() {

--- a/test/dom/privacy/indexTest.js
+++ b/test/dom/privacy/indexTest.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Privacy', function() {

--- a/test/dom/timings/indexTest.js
+++ b/test/dom/timings/indexTest.js
@@ -1,9 +1,5 @@
-'use strict';
-
-const createTestRunner = require('../../help/browsertimeRunner')
-    .createTestRunner,
-  assert = require('assert');
-
+import { createTestRunner } from '../../help/browsertimeRunner.js';
+import assert from 'node:assert';
 let BROWSERS = ['chrome', 'firefox'];
 
 describe('Timings', function() {

--- a/test/har/bestpractice/longHeadersTest.js
+++ b/test/har/bestpractice/longHeadersTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Investigate long response headers', function() {
   it('We should be able to know if headers are too long', function() {

--- a/test/har/bestpractice/manyHeadersTest.js
+++ b/test/har/bestpractice/manyHeadersTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Investigate many response headers', function() {
   it('We should be able to find responses with really many headers', function() {

--- a/test/har/bestpractice/unnecessaryHeadersTest.js
+++ b/test/har/bestpractice/unnecessaryHeadersTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Investigate response headers for headers we do not need', function() {
   it('We should find headers that we do not need', function() {

--- a/test/har/harCutterTest.js
+++ b/test/har/harCutterTest.js
@@ -1,8 +1,6 @@
-'use strict';
-
-let assert = require('assert');
-let harCutter = require('../../lib/har/harCutter').pickAPage;
-let helper = require('../help/har');
+import assert from 'node:assert';
+import { pickAPage as harCutter } from '../../lib/har/harCutter.js';
+import helper from '../help/har.js';
 
 describe('Test HAR cutter', function() {
   it('We should get the correct number of pages from the HAR cutter', function() {

--- a/test/har/info/technologyTest.js
+++ b/test/har/info/technologyTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Check for technology', function() {
   it('We shave the right amount of technologies', function() {

--- a/test/har/performance/assetsRedirectsTest.js
+++ b/test/har/performance/assetsRedirectsTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Avoid redirects for the assets', function() {
   it('We should be able to find redirects on assets', function() {

--- a/test/har/performance/cacheHeadersLongTest.js
+++ b/test/har/performance/cacheHeadersLongTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Use cache headers', function() {
   it('We should be able to know if cache times are too short', function() {

--- a/test/har/performance/cacheHeadersTest.js
+++ b/test/har/performance/cacheHeadersTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Use cache headers', function() {
   it('We should be able to know if we have failing cache headers', function() {

--- a/test/har/performance/compressAssetsTest.js
+++ b/test/har/performance/compressAssetsTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Always compress text content', function() {
   it('We should be able to know that all content is compressed', function() {

--- a/test/har/performance/connectionKeepAliveTest.js
+++ b/test/har/performance/connectionKeepAliveTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Avoid closing a connection that can be used again', function() {
   it('We should be able to find connection close', function() {

--- a/test/har/performance/cpuTimeSpentInRenderingTest.js
+++ b/test/har/performance/cpuTimeSpentInRenderingTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Find too long time spent in rendering', function() {
   it('We should be ble to find long time spent in rendering', function() {

--- a/test/har/performance/cpuTimeSpentInScriptingTest.js
+++ b/test/har/performance/cpuTimeSpentInScriptingTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Find too long time spent in scripting', function() {
   it('We should be ble to find long time spent in scripting', function() {

--- a/test/har/performance/cssSizeTest.js
+++ b/test/har/performance/cssSizeTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe("Don't send too much CSS to the browser", function() {
   it('We should be able to know if there are too much CSS', function() {

--- a/test/har/performance/documentRedirectTest.js
+++ b/test/har/performance/documentRedirectTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Never do redirects on the main document', function() {
   it("We should be able to find out if page don't do a redirect", function() {

--- a/test/har/performance/faviconTest.js
+++ b/test/har/performance/faviconTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Use favicon', function() {
   it('We should be able to know if we have a favicon', function() {

--- a/test/har/performance/fewFontsTest.js
+++ b/test/har/performance/fewFontsTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Avoid multiple fonts on a page', function() {
   it('We should be able to find multiple fonts on a page', function() {

--- a/test/har/performance/fewRequestsPerDomainTest.js
+++ b/test/har/performance/fewRequestsPerDomainTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Avoid loading too many assets from one domain on HTTP/1', function() {
   it('We should be able to find to many assets on one domain', function() {

--- a/test/har/performance/headerSizeTest.js
+++ b/test/har/performance/headerSizeTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe("Don't send too much data in the headers", function() {
   it('We should be able to know if there are too large headers', function() {

--- a/test/har/performance/imageSizeTest.js
+++ b/test/har/performance/imageSizeTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe("Don't send too large images to the browser", function() {
   it('We should be able to know if there are too much image data', function() {

--- a/test/har/performance/javascriptSizeTest.js
+++ b/test/har/performance/javascriptSizeTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe("Don't send too many JavaScript files to the browser", function() {
   it('We should be able to know if there are too many JavaScript files', function() {

--- a/test/har/performance/mimeTypes.js
+++ b/test/har/performance/mimeTypes.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 const harfileCorrect = 'mimeTypesCorrect.har';
 const harfileIncorrect = 'mimeTypesIncorrect.har';
 /*

--- a/test/har/performance/optimalCssSizeTest.js
+++ b/test/har/performance/optimalCssSizeTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe("Don't let the CSS files be too large", function() {
   it('We should be able to know if a CSS file is too large', function() {

--- a/test/har/performance/pageSizeTest.js
+++ b/test/har/performance/pageSizeTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Avoid bloated pages', function() {
   it('We should be able to know if a page is not too large', function() {

--- a/test/har/performance/privateAssetsTest.js
+++ b/test/har/performance/privateAssetsTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Avoid setting private headers on items that can be cached', function() {
   it('We should be able to find cache headers that are private', function() {

--- a/test/har/performance/responseOkTest.js
+++ b/test/har/performance/responseOkTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Avoid 40X and 50X', function() {
   it('We should be able to know if we have an error in one request', function() {

--- a/test/har/privacy/referrerPolicyHeaderTest.js
+++ b/test/har/privacy/referrerPolicyHeaderTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Search for referrer policy header', function() {
   it('We should be able to find if we do not have a referrer policy header', function() {

--- a/test/har/privacy/strictTransportSecurityHeaderTest.js
+++ b/test/har/privacy/strictTransportSecurityHeaderTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let har = require('../../help/har');
+import assert from 'node:assert';
+import har from '../../help/har.js';
 
 describe('Search for strict transport security header', function() {
   it('We should be able to find strict transport security header', function() {

--- a/test/har/utilTest.js
+++ b/test/har/utilTest.js
@@ -1,7 +1,5 @@
-'use strict';
-
-let assert = require('assert');
-let util = require('../../lib/har/util');
+import assert from 'node:assert';
+import * as util from '../../lib/har/util.js';
 
 describe('Test HAR util functions', function() {
   it('Categorize connection types H2 as HTTP/2 and nothing else', function() {

--- a/test/help/browsertimeRunner.js
+++ b/test/help/browsertimeRunner.js
@@ -1,10 +1,8 @@
-'use strict';
-
-let Promise = require('bluebird'),
-  urlParser = require('url'),
-  fs = require('fs'),
-  webserver = require('./webserver'),
-  path = require('path');
+import Promise from 'bluebird';
+import urlParser from 'node:url';
+import fs from 'node:fs';
+import webserver from './webserver.js';
+import path from 'node:path';
 
 Promise.promisifyAll(fs);
 
@@ -23,7 +21,7 @@ function getScript(ruleFileName, category) {
   );
 }
 
-module.exports = {
+export default {
   async createTestRunner(browser, category, useHttp2) {
     function run(url, script) {
       return Promise.resolve(script).then(script =>

--- a/test/help/har.js
+++ b/test/help/har.js
@@ -1,22 +1,23 @@
-'use strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as api from '../../lib/index.js';
 
-let fs = require('fs'),
-  Promise = require('bluebird'),
-  path = require('path'),
-  api = require('../../lib/');
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
-Promise.promisifyAll(fs);
+export async function harFromTestFile(fileName) {
+  const text = await readFile(
+    resolve(__dirname, '..', 'har', 'files', fileName),
+    'utf8'
+  );
+  return JSON.parse(text);
+}
 
-module.exports = {
-  harFromTestFile(fileName) {
-    return fs
-      .readFileAsync(path.resolve(__dirname, '..', 'har', 'files', fileName))
-      .then(JSON.parse);
-  },
-  async firstAdviceForTestFile(fileName, options) {
-    const advice = await api.getHarAdvice();
-    return this.harFromTestFile(fileName)
-      .then(har => api.analyseHar(har, advice, undefined, options))
-      .then(result => result[0].advice);
-  }
-};
+export async function firstAdviceForTestFile(fileName, options) {
+  const advice = await api.getHarAdvice();
+  const har = await harFromTestFile(fileName);
+  const result = await api.analyseHar(har, advice, undefined, options);
+  return result[0].advice;
+}
+
+export default { harFromTestFile, firstAdviceForTestFile };

--- a/test/help/webserver.js
+++ b/test/help/webserver.js
@@ -1,29 +1,27 @@
-'use strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import http from 'node:http';
+import http2 from 'node:http2';
+import connect from 'connect';
+import serveStatic from 'serve-static';
 
-const Promise = require('bluebird');
-const fs = require('fs');
-const connect = require('connect');
-const serveStatic = require('serve-static');
-const http = require('http');
-const http2 = require('http2');
-const path = require('path');
-
-Promise.promisifyAll(fs);
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 let server;
 let isListening = false;
 
 function createServer(useHttp2) {
-  const testdataFolder = path.join(__dirname, '..');
+  const testdataFolder = join(__dirname, '..');
   const app = connect();
 
-  app.use(serveStatic(path.resolve(testdataFolder, 'http-server'), {}));
+  app.use(serveStatic(resolve(testdataFolder, 'http-server'), {}));
 
   if (useHttp2) {
-    const certsFolder = path.join(testdataFolder, 'testdata', 'certs');
+    const certsFolder = join(testdataFolder, 'testdata', 'certs');
     const httpsOptions = {
-      key: fs.readFileSync(path.join(certsFolder, 'server.key'), 'utf8'),
-      cert: fs.readFileSync(path.join(certsFolder, 'server.crt'), 'utf8'),
+      key: readFileSync(join(certsFolder, 'server.key'), 'utf8'),
+      cert: readFileSync(join(certsFolder, 'server.crt'), 'utf8'),
       passphrase: 'coach'
     };
 
@@ -33,32 +31,30 @@ function createServer(useHttp2) {
   }
 }
 
-module.exports = {
-  async startServer(useHttp2) {
-    if (!server) {
-      server = createServer(useHttp2);
-    }
-
-    if (!isListening) {
-      await new Promise((resolve, reject) => {
-        server
-          .listen(0, '0.0.0.0')
-          .on('error', reject)
-          .on('listening', () => {
-            isListening = true;
-            resolve(server.address());
-          });
-      });
-    }
-
-    return server.address();
-  },
-
-  async stopServer() {
-    if (server && isListening) {
-      await Promise.resolve(server.close());
-      server = undefined;
-      isListening = false;
-    }
+export async function startServer(useHttp2) {
+  if (!server) {
+    server = createServer(useHttp2);
   }
-};
+
+  if (!isListening) {
+    await new Promise((resolveCb, rejectCb) => {
+      server
+        .listen(0, '0.0.0.0')
+        .on('error', rejectCb)
+        .on('listening', () => {
+          isListening = true;
+          resolveCb(server.address());
+        });
+    });
+  }
+
+  return server.address();
+}
+
+export async function stopServer() {
+  if (server && isListening) {
+    await Promise.resolve(server.close());
+    server = undefined;
+    isListening = false;
+  }
+}

--- a/test/merge/mergeTest.js
+++ b/test/merge/mergeTest.js
@@ -1,11 +1,11 @@
-'use strict';
+import { merge } from '../../lib/merge.js';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
 
-let merge = require('../../lib/merge').merge;
-let assert = require('assert');
-
-let domResult = require('./files/domResult.json');
-let harResult = require('./files/harResult.json');
-let harResultOverride = require('./files/harResultOverride.json');
+const require = createRequire(import.meta.url);
+const domResult = require('./files/domResult.json');
+const harResult = require('./files/harResult.json');
+const harResultOverride = require('./files/harResultOverride.json');
 
 describe('Merging DOM and HAR results', function() {
   it('We should have the right amount of performance advice', function() {

--- a/test/merge/severityTest.js
+++ b/test/merge/severityTest.js
@@ -1,9 +1,9 @@
-'use strict';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { merge } from '../../lib/merge.js';
+import * as severity from '../../lib/severity.js';
 
-const assert = require('assert');
-const merge = require('../../lib/merge').merge;
-const severity = require('../../lib/severity');
-
+const require = createRequire(import.meta.url);
 const domResult = require('./files/domResult.json');
 const harResult = require('./files/harResult.json');
 

--- a/tools/combine.js
+++ b/tools/combine.js
@@ -1,33 +1,36 @@
 #!/usr/bin/env node
 
-'use strict';
+import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, basename, extname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import filter from 'filter-files';
 
-const path = require('path'),
-  fs = require('fs'),
-  packageInfo = require('../package'),
-  filter = require('filter-files');
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const packageInfo = require('../package.json');
 
-const filterJsFiles = file => path.extname(file) === '.js';
+const filterJsFiles = (file) => extname(file) === '.js';
 const filterDirs = (file, dir) =>
-  fs.statSync(path.resolve(dir, file)).isDirectory();
+  statSync(resolve(dir, file)).isDirectory();
 
 const fileContentsByName = (scripts, file) => {
-  const name = path.basename(file, '.js');
-  scripts[name] = fs.readFileSync(file, 'utf8');
+  const name = basename(file, '.js');
+  scripts[name] = readFileSync(file, 'utf8');
   return scripts;
 };
 
-module.exports = function(filename) {
-  const utilsSrc = fs.readFileSync(path.join(__dirname, '../lib/dom/util.js')),
-    calculateScoreSrc = fs.readFileSync(
-      path.join(__dirname, 'calculateScore.js')
+export default function combine(filename) {
+  const utilsSrc = readFileSync(join(__dirname, '../lib/dom/util.js')),
+    calculateScoreSrc = readFileSync(
+      join(__dirname, 'calculateScore.js')
     ),
-    categoriesPath = path.join(__dirname, '../lib/dom');
+    categoriesPath = join(__dirname, '../lib/dom');
 
   const categoryDirs = filter.sync(categoriesPath, filterDirs, false);
 
   const scriptsByCategory = categoryDirs.reduce((byCategory, categoryDir) => {
-    const categoryName = path.basename(categoryDir);
+    const categoryName = basename(categoryDir);
     byCategory[categoryName] = filter
       .sync(categoryDir, filterJsFiles, false)
       .reduce(fileContentsByName, {});
@@ -35,11 +38,11 @@ module.exports = function(filename) {
   }, {});
 
   const pushResultsSrc = Object.keys(scriptsByCategory)
-    .map(categoryId => {
+    .map((categoryId) => {
       let scriptsById = scriptsByCategory[categoryId];
       let pushResultsSrc = Object.keys(scriptsById)
         .map(
-          scriptId =>
+          (scriptId) =>
             `try {
             ${categoryId}Results["${scriptId}"] = ${scriptsById[scriptId]}
           } catch(err) {
@@ -100,9 +103,10 @@ module.exports = function(filename) {
   })();
 `;
 
-  fs.writeFileSync(filename, combinedSrc);
-};
+  writeFileSync(filename, combinedSrc);
+}
 
-if (!module.parent) {
-  module.exports(process.argv[2]);
+// Run as CLI when invoked directly.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  combine(process.argv[2]);
 }


### PR DESCRIPTION
  Brings coach-core in line with the rest of the sitespeed.io family (browsertime, sitespeed.io etc.), all of which
  moved to "type": "module" and import/export some time ago. The CJS shape was becoming the awkward outlier —
  sitespeed.io itself can't cleanly require a CJS dependency from its ESM entry, and tests in this repo had to keep
  promisifying fs through bluebird because they predate node:fs/promises.

  Following the browsertime / sitespeed convention: ".js" everywhere with "type": "module" rather than ".mjs", node:
  prefixed built-ins, named exports for utility modules with namespace imports at call sites so existing util.foo()
  lines don't change, createRequire(import.meta.url) for JSON loads instead of import attributes (so the package keeps
  working on the older Node versions in CI), and import.meta.url + fileURLToPath wherever __dirname was used.

  The DOM rule files under lib/dom remain non-module IIFE scripts; they are concatenated into a single browser bundle
  by tools/combine.js and never ran as Node modules. The eslint config keeps them under sourceType: script with the
  browser globals.

  The engines.node minimum bumps from 18 to 20 to match browsertime, and the lock file regeneration on top of that is
  harmless.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com