### PR TITLE
Add NEL and Reporting-Endpoints header rules

### DIFF
--- a/lib/har/privacy/nelHeader.js
+++ b/lib/har/privacy/nelHeader.js
@@ -1,0 +1,34 @@
+export default {
+  id: 'nelHeader',
+  title: 'Set a NEL header so the browser reports network errors back to you.',
+  description:
+    'The NEL (Network Error Logging) response header tells the browser to record connection-level failures (DNS, TLS, HTTP errors) and ship them to a reporting endpoint. NEL pairs with the Reporting-Endpoints / Report-To header — the page declares the endpoint group and NEL points at it. Together they give you visibility into errors that never reach your origin server. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/NEL',
+  weight: 2,
+  severity: 'info',
+  tags: ['headers', 'privacy', 'observability'],
+  processPage: function (page) {
+    const offending = [];
+    let score = 0;
+    let advice = '';
+    const finalUrl = page.finalUrl;
+    page.assets.forEach(function (asset) {
+      if (asset.url === finalUrl) {
+        const headers = asset.headers.response;
+        if (headers['nel']) {
+          score = 100;
+        } else {
+          offending.push(asset.url);
+        }
+      }
+    });
+    if (score === 0) {
+      advice =
+        'Set a NEL header (paired with Reporting-Endpoints) to collect connection-level error reports from the field.';
+    }
+    return {
+      score: score,
+      offending: offending,
+      advice: advice
+    };
+  }
+};

--- a/lib/har/privacy/reportingEndpointsHeader.js
+++ b/lib/har/privacy/reportingEndpointsHeader.js
@@ -1,0 +1,37 @@
+export default {
+  id: 'reportingEndpointsHeader',
+  title:
+    'Declare reporting endpoints so the browser can deliver Reporting-API events.',
+  description:
+    'The Reporting-Endpoints response header (the successor to Report-To) names the URLs that browsers should POST reports to. Without it, CSP report-to directives, Cross-Origin-Opener-Policy reports, NEL data and other Reporting-API events have nowhere to go. The legacy Report-To header is still accepted for older Chromium versions. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Reporting-Endpoints',
+  weight: 2,
+  severity: 'info',
+  tags: ['headers', 'privacy', 'observability'],
+  processPage: function (page) {
+    const offending = [];
+    let score = 0;
+    let advice = '';
+    const finalUrl = page.finalUrl;
+    page.assets.forEach(function (asset) {
+      if (asset.url === finalUrl) {
+        const headers = asset.headers.response;
+        // Reporting-Endpoints is the modern shape; Report-To is the
+        // deprecated predecessor still used by older Chromium clients.
+        if (headers['reporting-endpoints'] || headers['report-to']) {
+          score = 100;
+        } else {
+          offending.push(asset.url);
+        }
+      }
+    });
+    if (score === 0) {
+      advice =
+        'Set a Reporting-Endpoints header (or the legacy Report-To header) so CSP reports, NEL data and other Reporting-API events have an endpoint to land at.';
+    }
+    return {
+      score: score,
+      offending: offending,
+      advice: advice
+    };
+  }
+};


### PR DESCRIPTION
  Two thin presence checks following the same shape as the existing referrer-policy / Permissions-Policy /
  X-Content-Type-Options rules. NEL (Network Error Logging) tells the browser to record connection-level failures;
  Reporting-Endpoints (and the deprecated Report-To) tell it where to ship those reports. Either header is interesting
  on its own but they only do useful work as a pair, and the advice texts cross-reference each other.

  Both ship with weight 2 and severity info because reporting infrastructure is observability, not a security baseline
  like CSP or HSTS — useful to have, but not something to fail a page over.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com