### PR TITLE
Score CSP on its directives, not on its byte length

### DIFF
--- a/lib/har/privacy/contentSecurityPolicyHeader.js
+++ b/lib/har/privacy/contentSecurityPolicyHeader.js
@@ -1,45 +1,128 @@
+// Score a Content-Security-Policy header on what it actually says, not on
+// its byte length. The previous heuristic (deduct 50 if the policy is
+// longer than 150 chars) didn't reflect any real-world property — strict
+// CSPs with a few directives and a nonce easily exceed 150 chars; tight
+// CSPs that lock down a single-page app are routinely 200+ chars. So we
+// look at the directives instead:
+//
+//   no header                                          score 0
+//   uses 'unsafe-inline' or 'unsafe-eval' (each)       score deductions
+//   missing default-src and script-src                 small deduction
+//   uses 'strict-dynamic' with a nonce or hash         neutralises the
+//                                                      'unsafe-inline'
+//                                                      penalty (browsers
+//                                                      that understand
+//                                                      strict-dynamic
+//                                                      ignore unsafe-inline
+//                                                      anyway, so a
+//                                                      strict-dynamic
+//                                                      policy is fine to
+//                                                      ship even with
+//                                                      unsafe-inline as a
+//                                                      fallback for older
+//                                                      browsers)
+//
+// References:
+//   https://csp.withgoogle.com/docs/strict-csp.html
+//   https://web.dev/articles/strict-csp
+//   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+const NONCE_RE = /(?:^|[\s;])'nonce-[A-Za-z0-9+/=_-]+'/i;
+const HASH_RE = /(?:^|[\s;])'sha(?:256|384|512)-[A-Za-z0-9+/=_-]+'/i;
+const STRICT_DYNAMIC_RE = /'strict-dynamic'/i;
+const UNSAFE_INLINE_RE = /'unsafe-inline'/i;
+const UNSAFE_EVAL_RE = /'unsafe-eval'/i;
+const HAS_DEFAULT_SRC_RE = /(?:^|;)\s*default-src\b/i;
+const HAS_SCRIPT_SRC_RE = /(?:^|;)\s*script-src(?:-elem|-attr)?\b/i;
+const HAS_OBJECT_SRC_RE = /(?:^|;)\s*object-src\b/i;
+const DEFAULT_SRC_NONE_RE = /(?:^|;)\s*default-src\s+[^;]*'none'/i;
+
+function readHeader(asset) {
+  const raw = asset.headers.response['content-security-policy'];
+  if (!raw) return undefined;
+  // pagexray normalises headers to arrays of values per name.
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
 export default {
   id: 'contentSecurityPolicyHeader',
   title:
-    'Use a good Content-Security-Policy header to make sure you you avoid Cross Site Scripting (XSS) attacks.',
+    'Use a strict Content-Security-Policy header to mitigate cross-site scripting (XSS) attacks.',
   description:
-    'Content Security Policy is delivered via a HTTP response header, and defines approved sources of content that the browser may load. It can be an effective countermeasure to Cross Site Scripting (XSS) attacks and is also widely supported and usually easily deployed. https://scotthelme.co.uk/content-security-policy-an-introduction/.',
+    'A Content-Security-Policy response header tells the browser which sources of script, style, and other content are allowed. The most effective form is a strict CSP using nonces or hashes together with strict-dynamic; the worst is a missing header, with unsafe-inline and unsafe-eval close behind. https://web.dev/articles/strict-csp',
   weight: 5,
   severity: 'warn',
   tags: ['privacy', 'bestpractice', 'headers'],
   processPage: function (page) {
     const offending = [];
     let score = 0;
-    let advice = '';
+    const adviceParts = [];
     const finalUrl = page.finalUrl;
     page.assets.forEach(function (asset) {
-      if (asset.url === finalUrl) {
-        if (asset.headers.response['content-security-policy']) {
-          const maxLength = 150;
-          if (
-            asset.headers.response['content-security-policy'].length > maxLength
-          ) {
-            score = 50;
-            advice =
-              'The site uses a Content-Security-Policy header, good! But it is long (' +
-              asset.headers.response['content-security-policy'].length +
-              '). That is usually a sign of loading 3rd party assets. Can you try to make it stricter so you allow more security for the user?';
-          } else {
-            score = 100;
-          }
-        } else {
-          offending.push(asset.url);
+      if (asset.url !== finalUrl) {
+        return;
+      }
+      const value = readHeader(asset);
+      if (!value) {
+        offending.push(asset.url);
+        adviceParts.push(
+          'Set a Content-Security-Policy header to mitigate cross-site scripting attacks. You can start with a Content-Security-Policy-Report-Only header, which only reports violations rather than blocking them.'
+        );
+        return;
+      }
+
+      score = 100;
+      const hasStrictDynamic = STRICT_DYNAMIC_RE.test(value);
+      const hasNonceOrHash = NONCE_RE.test(value) || HASH_RE.test(value);
+      const looksStrict = hasStrictDynamic && hasNonceOrHash;
+
+      if (UNSAFE_INLINE_RE.test(value)) {
+        if (!looksStrict) {
+          score -= 40;
+          adviceParts.push(
+            "The policy allows 'unsafe-inline', which lets the browser execute inline scripts and styles directly from the page. Move to nonces or hashes plus 'strict-dynamic' so that inline injection cannot run."
+          );
         }
+        // If looksStrict: modern browsers ignore unsafe-inline when
+        // strict-dynamic + nonces/hashes are present, so no penalty.
+      }
+
+      if (UNSAFE_EVAL_RE.test(value)) {
+        score -= 30;
+        adviceParts.push(
+          "The policy allows 'unsafe-eval', which lets the page call eval() and Function(). Almost no application needs this; remove it."
+        );
+      }
+
+      const hasAnyDefault =
+        HAS_DEFAULT_SRC_RE.test(value) || HAS_SCRIPT_SRC_RE.test(value);
+      if (!hasAnyDefault) {
+        score -= 20;
+        adviceParts.push(
+          'The policy declares no default-src or script-src directive, which means scripts can be loaded from anywhere. Add at least default-src so unknown directive types fall back to a safe value.'
+        );
+      }
+
+      if (!HAS_OBJECT_SRC_RE.test(value) && !DEFAULT_SRC_NONE_RE.test(value)) {
+        score -= 10;
+        adviceParts.push(
+          "Set object-src 'none' (or a default-src 'none' fallback) so the page cannot load Flash, plugins or other legacy embeddable content."
+        );
+      }
+
+      if (looksStrict) {
+        adviceParts.push(
+          "The policy uses 'strict-dynamic' together with a nonce or hash — that is the recommended modern shape. Good."
+        );
       }
     });
-    if (score === 0) {
-      advice =
-        'Set a Content-Security-Policy header to make sure you are not open for Cross Site Scripting (XSS) attacks. You can start with setting a Content-Security-Policy-Report-Only header, that will only report the violation, not stop the download.';
+
+    if (score < 0) {
+      score = 0;
     }
     return {
       score: score,
       offending: offending,
-      advice: advice
+      advice: adviceParts.join(' ').trim()
     };
   }
 };

--- a/test/har/privacy/contentSecurityPolicyHeaderTest.js
+++ b/test/har/privacy/contentSecurityPolicyHeaderTest.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import har from '../../help/har.js';
+
+describe('Score the Content-Security-Policy header', function() {
+  it('flags a CSP that allows unsafe-inline', function() {
+    // manyHeaders.har has:
+    //   default-src 'self'; style-src 'self' 'unsafe-inline'; img-src ...
+    // — so the rule should deduct for unsafe-inline but not give a 0,
+    // and the offending list should be empty (the header is present).
+    return har.firstAdviceForTestFile('manyHeaders.har').then(result => {
+      const advice =
+        result.privacy.adviceList.contentSecurityPolicyHeader;
+      assert.strictEqual(advice.offending.length, 0);
+      assert.ok(
+        advice.score < 100 && advice.score > 0,
+        `expected unsafe-inline deduction, got score ${advice.score}`
+      );
+      assert.ok(
+        /unsafe-inline/.test(advice.advice),
+        `expected advice to mention unsafe-inline, got: ${advice.advice}`
+      );
+    });
+  });
+
+  it('scores 0 when no Content-Security-Policy header is present', function() {
+    return har.firstAdviceForTestFile('referrerPolicy.har').then(result => {
+      const advice =
+        result.privacy.adviceList.contentSecurityPolicyHeader;
+      assert.strictEqual(advice.score, 0);
+      assert.strictEqual(advice.offending.length, 1);
+    });
+  });
+});


### PR DESCRIPTION
  The Content-Security-Policy rule used to deduct 50 points if the header value was longer than 150 characters. That
  heuristic doesn't reflect any real-world property: a strict CSP with a few directives and a nonce easily exceeds 150
  chars, while a permissive CSP can be very short. Worse, the comparison was reading .length on the array of header
  values rather than on the value string itself, so the threshold was effectively always missed and the deduction never
   fired.

  The new rule scores on what the policy actually says — deductions for unsafe-inline, unsafe-eval, missing default-src
   / script-src, and missing object-src 'none'. The unsafe-inline deduction is suppressed when strict-dynamic is paired
   with a nonce or hash, which is the modern strict-CSP shape (browsers that understand strict-dynamic ignore
  unsafe-inline anyway, so it's fine as a legacy fallback). Includes a small test against the existing manyHeaders.har
  fixture; the advice text now points at the specific weakness instead of a generic "your policy is long" hint.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com