### PR TITLE
Extend the surveillance hostname list

### DIFF
--- a/lib/dom/privacy/surveillance.js
+++ b/lib/dom/privacy/surveillance.js
@@ -1,20 +1,61 @@
 (function (util) {
   'use strict';
 
-  // Hostnames whose business model is surveillance capitalism. We match by
-  // exact host or by suffix (e.g. www.google-analytics.com), never by raw
-  // substring, so that mygoogle.com / facebook-clone.com don't false-match.
+  // Hostnames whose business model is surveillance capitalism. The list
+  // covers ad-tech, conversion-tracking pixels and behavioural-analytics
+  // tags from the major social, search and ad networks. Session-replay
+  // tools (Hotjar, FullStory, Microsoft Clarity etc.) are intentionally
+  // not included here — they are a different product category and deserve
+  // their own rule with their own advice ("configure redaction, get
+  // consent" rather than "stop using this").
+  //
+  // We match by exact host or by suffix (e.g. www.google-analytics.com is
+  // a suffix-match for google-analytics.com), never by raw substring, so
+  // mygoogle.com / facebook-clone.com don't false-match.
   const surveillanceDomains = [
+    // Google ad / analytics
     'google-analytics.com',
     'googletagmanager.com',
     'doubleclick.net',
     'googlesyndication.com',
     'googleadservices.com',
     'googletagservices.com',
+    // Meta
     'facebook.com',
     'facebook.net',
     'fbcdn.net',
-    'youtube.com'
+    // YouTube (Google) — embed traffic is tracked
+    'youtube.com',
+    // X / Twitter
+    'twitter.com',
+    'twimg.com',
+    't.co',
+    'ads-twitter.com',
+    // LinkedIn (Insight Tag)
+    'linkedin.com',
+    'licdn.com',
+    // TikTok (pixel + CDN + parent)
+    'tiktok.com',
+    'tiktokcdn.com',
+    'tiktokv.com',
+    'bytedance.com',
+    // Snapchat
+    'snapchat.com',
+    'snap.com',
+    'sc-static.net',
+    // Pinterest
+    'pinterest.com',
+    'pinimg.com',
+    // Reddit
+    'reddit.com',
+    'redditstatic.com',
+    // Microsoft (Bing Ads / UET)
+    'bat.bing.com',
+    // Yandex Metrica
+    'mc.yandex.ru',
+    'mc.yandex.com',
+    // Baidu Tongji
+    'hm.baidu.com'
   ];
 
   function isSurveillanceHost(url) {


### PR DESCRIPTION
  Adds X / Twitter, LinkedIn, TikTok, Snapchat, Pinterest, Reddit, Bing Ads, Yandex Metrica and Baidu Tongji to the
  ad-tech / tracking-pixel domains the surveillance rule already flags. Each entry is grouped by company and commented
  inline so the editorial intent stays visible if the list grows further.

  Session-replay tools (Hotjar, FullStory, Clarity, Smartlook etc.) are intentionally not in this list — they are a
  different product category, with different remediation advice ("configure redaction, get consent" rather than "stop
  using this") — and warrant their own rule when we want one. The code comment explains that choice so future
  contributors don't have to re-derive it.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com