### PR TITLE
Refresh stale rule thresholds

### DIFF
--- a/lib/dom/bestpractice/metaDescription.js
+++ b/lib/dom/bestpractice/metaDescription.js
@@ -1,7 +1,7 @@
 (function (util) {
   'use strict';
 
-  const maxLength = 155;
+  const maxLength = 160;
   let score = 100;
   let message = '';
   let metas = Array.prototype.slice.call(

--- a/lib/har/performance/cacheHeaders.js
+++ b/lib/har/performance/cacheHeaders.js
@@ -11,7 +11,7 @@ export default {
   title: 'Avoid extra requests by setting cache headers',
   description:
     "The easiest way to make your page fast is to avoid doing requests to the server. Setting a cache header on your server response will tell the browser that it doesn't need to download the asset again during the configured cache time! Always try to set a cache time if the content doesn't change for every request.",
-  weight: 30,
+  weight: 6,
   severity: 'warn',
   tags: ['performance', 'server'],
 

--- a/lib/har/performance/cacheHeadersLong.js
+++ b/lib/har/performance/cacheHeadersLong.js
@@ -6,10 +6,16 @@ const SKIPPABLE_DOMAINS = [
   'analytics.twitter.com'
 ];
 
+// One year in seconds — the cache lifetime modern best practice (and the
+// HTTP/1.1 spec) recommends as the upper bound. For content-hashed URLs
+// (e.g. /static/app.4af2.css) this is what `Cache-Control:
+// max-age=31536000, immutable` is designed for.
+const ONE_YEAR = 31536000;
+
 function processAsset(asset) {
   if (SKIPPABLE_DOMAINS.indexOf(util.getHostname(asset.url)) > -1) {
     return 0;
-  } else if (asset.expires >= 2592000) {
+  } else if (asset.expires >= ONE_YEAR) {
     return 0;
   } else if (asset.expires <= 0) {
     // this is caught in cacheHeaders so let's skip giving advice
@@ -24,7 +30,7 @@ export default {
   id: 'cacheHeadersLong',
   title: 'Long cache headers is good',
   description:
-    'Setting a cache header is good. Setting a long cache header (at least 30 days) is even better beacause then it will stay long in the browser cache. But what do you do if that asset change? Rename it and the browser will pick up the new version.',
+    'Setting a cache header is good. Setting a long cache header (a year) is even better because the asset will stay in the browser cache across visits. For content-hashed URLs (e.g. app.4af2.css) you can safely use Cache-Control: max-age=31536000, immutable. For unversioned URLs that may change, use a revalidating strategy instead.',
   weight: 3,
   severity: 'info',
   tags: ['performance', 'server'],
@@ -52,7 +58,7 @@ export default {
         score < 100
           ? 'The page has ' +
             util.plural(offending.length, 'request') +
-            ' that have a shorter cache time than 30 days (but still a cache time).'
+            ' that have a shorter cache time than one year (but still a cache time).'
           : ''
     };
   }

--- a/lib/har/performance/cssSize.js
+++ b/lib/har/performance/cssSize.js
@@ -13,8 +13,8 @@ export default {
     let cssAssets = page.assets.filter((asset) => asset.type === 'css');
     let transferSize = 0;
     let contentSize = 0;
-    let transferLimit = 120000;
-    let contentLimit = 400000;
+    let transferLimit = 150000;
+    let contentLimit = 500000;
     let score = 100;
     let advice = '';
     const offending = [];

--- a/lib/har/performance/javascriptSize.js
+++ b/lib/har/performance/javascriptSize.js
@@ -13,8 +13,8 @@ export default {
     let jsAssets = page.assets.filter((asset) => asset.type === 'javascript');
     let transferSize = 0;
     let contentSize = 0;
-    let transferLimit = 120000;
-    let contentLimit = 500000;
+    let transferLimit = 250000;
+    let contentLimit = 800000;
     let score = 100;
     const offending = [];
 

--- a/lib/har/performance/optimalCssSize.js
+++ b/lib/har/performance/optimalCssSize.js
@@ -1,23 +1,29 @@
 import * as util from '../util.js';
 
+// Each render-blocking CSS file delays first paint until it has
+// downloaded, parsed and applied. Smaller is faster, and a single CSS
+// response above ~25 KB is usually a sign of mixed critical and
+// non-critical styles being shipped together — split out the critical
+// rules and lazy-load the rest.
+const TRANSFER_LIMIT = 25000;
+
 export default {
   id: 'optimalCssSize',
   title: 'Make each CSS response small',
   description:
-    'Make CSS responses small to fit into the magic number TCP window size of 14.5 KB. The browser can then download the CSS faster and that will make the page start rendering earlier.',
+    'Render-blocking CSS holds up the first paint until it has fully downloaded, parsed and applied, so smaller CSS files mean a faster start. Split your CSS into a small critical bundle inlined or eagerly loaded, with the rest lazy-loaded.',
   weight: 3,
   severity: 'info',
   tags: ['performance', 'css'],
 
   processPage: function (page) {
     let cssAssets = page.assets.filter((asset) => asset.type === 'css');
-    let transferLimit = 14500;
     let score = 100;
     let advice = '';
     let offending = [];
 
     cssAssets.forEach(function (asset) {
-      if (asset.transferSize > transferLimit) {
+      if (asset.transferSize > TRANSFER_LIMIT) {
         score -= 10;
         offending.push({
           url: asset.url,
@@ -31,13 +37,16 @@ export default {
           ' (' +
           asset.transferSize +
           ') and that is bigger than the limit of ' +
-          util.formatBytes(transferLimit) +
+          util.formatBytes(TRANSFER_LIMIT) +
           '. ';
       }
     });
 
     if (score < 100) {
-      advice += 'Try to make the CSS files fit into 14.5 KB.';
+      advice +=
+        'Try to keep each CSS response under ' +
+        util.formatBytes(TRANSFER_LIMIT) +
+        '.';
     }
 
     if (score < 0) {

--- a/lib/har/performance/pageSize.js
+++ b/lib/har/performance/pageSize.js
@@ -4,12 +4,12 @@ export default {
   id: 'pageSize',
   title: "Total page size shouldn't be too big",
   description:
-    'Avoid having pages that have a transfer size over the wire of more than 2 MB (desktop) and 1 MB (mobile) because that is really big and will hurt performance and will make the page expensive for the user if she/he pays for the bandwidth.',
+    'Avoid having pages that have a transfer size over the wire of more than 3 MB (desktop) and 2 MB (mobile) because heavy pages hurt performance and are expensive for users on metered connections. Reference: HTTP Archive median page weight in 2024 was around 2.7 MB desktop / 2.4 MB mobile, so this rule fires when a page is above the modern median.',
   weight: 3,
   severity: 'warn',
   tags: ['performance', 'mobile'],
   processPage: function (page, domAdvice, options) {
-    let sizeLimit = options.mobile ? 1000000 : 2000000;
+    let sizeLimit = options.mobile ? 2000000 : 3000000;
     if (page.transferSize > sizeLimit) {
       const offending = [];
       page.assets.forEach(function (asset) {

--- a/lib/har/privacy/strictTransportSecurityHeader.js
+++ b/lib/har/privacy/strictTransportSecurityHeader.js
@@ -33,11 +33,14 @@ export default {
                 const time = Number(
                   parts[0].substring(parts[0].indexOf('=') + 1, parts[0].length)
                 );
-                const minSixMonth = 15768000;
-                if (time < minSixMonth) {
+                // The HSTS preload list (https://hstspreload.org)
+                // requires max-age >= 31536000 (one year). Anything below
+                // that is below the practical security baseline.
+                const minOneYear = 31536000;
+                if (time < minOneYear) {
                   score -= 20;
                   advice +=
-                    'The max age is lower than six months. Increase it to get a better score.';
+                    'The max-age is lower than one year, which is below the HSTS preload list minimum. Set it to at least 31536000 (one year), and 63072000 (two years) is recommended.';
                 }
               }
             }

--- a/test/har/performance/cacheHeadersLongTest.js
+++ b/test/har/performance/cacheHeadersLongTest.js
@@ -6,12 +6,13 @@ describe('Use cache headers', function() {
     return har.firstAdviceForTestFile('cacheHeaders.har').then(result => {
       assert.strictEqual(
         result.performance.adviceList.cacheHeadersLong.score,
-        70
+        0
       );
-      // massive
+      // massive — the fixture has 114 assets with cache times shorter
+      // than one year (the new threshold; was 30 days previously).
       assert.strictEqual(
         result.performance.adviceList.cacheHeadersLong.offending.length,
-        30
+        114
       );
     });
   });

--- a/test/har/performance/pageSizeTest.js
+++ b/test/har/performance/pageSizeTest.js
@@ -9,8 +9,13 @@ describe('Avoid bloated pages', function() {
   });
 
   it('We should be able to know if a page is too large', function() {
-    return har.firstAdviceForTestFile('pageSize2.har').then(result => {
-      assert.strictEqual(result.performance.adviceList.pageSize.score, 0);
-    });
+    // The fixture is ~2.33 MB. Under the modernised thresholds
+    // (3 MB desktop / 2 MB mobile) that's fine on desktop but fails
+    // on mobile, so we exercise mobile mode here.
+    return har
+      .firstAdviceForTestFile('pageSize2.har', { mobile: true })
+      .then(result => {
+        assert.strictEqual(result.performance.adviceList.pageSize.score, 0);
+      });
   });
 });


### PR DESCRIPTION
  The rules are full of hardcoded numbers chosen years ago that haven't kept up with the modern web. Some were stale on
   the conservative side (HSTS 6 months, where the preload list now requires 1 year); some on the lenient side
  (cacheHeadersLong's 30-day floor, where best practice for content-hashed URLs is 1 year + immutable); and some were
  out of band entirely (cacheHeaders weight 30 in a codebase where every other rule is 1–10).

  This pass updates seven rules:
  - metaDescription max length 155 → 160 chars (matches Google's modern search-results display)
  - cacheHeadersLong floor 30 days → 1 year (HSTS preload, immutable best practice)
  - strictTransportSecurityHeader max-age floor 6 months → 1 year (HSTS preload list minimum)
  - cacheHeaders weight 30 → 6 (in line with the rest of the rule set)
  - pageSize 1 / 2 MB → 2 / 3 MB mobile / desktop (HTTP Archive 2024 median is ~2.4 / 2.7 MB; the rule now fires on above-median pages rather than every page)
  - cssSize 120 / 400 KB → 150 / 500 KB transfer / content
  - javascriptSize 120 / 500 KB → 250 / 800 KB transfer / content
  - optimalCssSize 14.5 KB → 25 KB, with the "magic number TCP window" framing dropped (the IW10 argument is much weaker under HTTP/2 and HTTP/3 multiplexing; smaller-is-still-faster is the underlying point)

  Several rule descriptions and advice strings were rewritten to drop dated framings ("magic number TCP window", "30
  days") and to point at the modern reference (HTTP Archive medians, HSTS preload, content-hashed URLs with immutable).
   Two test fixtures needed assertion bumps to track the new thresholds — both kept their original intent (the
  cacheHeaders fixture really does have shorter cache than 1 year; the pageSize fixture is genuinely too big on mobile
  at the new 2 MB threshold).

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com