### PR TITLE
Add modern image and LCP-hint performance rules

### DIFF
--- a/lib/dom/performance/decodingAsync.js
+++ b/lib/dom/performance/decodingAsync.js
@@ -1,0 +1,58 @@
+(function (util) {
+  'use strict';
+  // `decoding="async"` lets the browser decode an image off the main
+  // thread, which keeps interaction (and other rendering work)
+  // responsive while the image is being processed. The default is
+  // `decoding="auto"` which leaves the choice to the browser; setting
+  // it explicitly to `async` is the safest hint for non-LCP images.
+  //
+  // We only flag images that don't have any decoding hint at all. We
+  // don't flag `decoding="sync"` (the author may have a reason, e.g. a
+  // first-paint image where they want to ensure synchronous decode) and
+  // we don't flag `decoding="auto"` (the explicit default).
+  const offending = [];
+  const images = document.getElementsByTagName('img');
+  let unhinted = 0;
+  let total = 0;
+
+  for (let i = 0, len = images.length; i < len; i++) {
+    const img = images[i];
+    if (!img.src && !img.currentSrc) {
+      continue;
+    }
+    total++;
+    if (!img.hasAttribute('decoding')) {
+      unhinted++;
+      offending.push(util.getAbsoluteURL(img.currentSrc || img.src));
+    }
+  }
+
+  // Score linearly with the proportion of images that lack the hint.
+  // 0% unhinted → 100, 100% unhinted → 0. We don't want to fail a page
+  // that has a single un-hinted image hard, so this stays gentle.
+  let score = 100;
+  let advice = '';
+  if (total > 0 && unhinted > 0) {
+    const ratio = unhinted / total;
+    score = Math.round(100 * (1 - ratio));
+    advice =
+      'The page has ' +
+      util.plural(unhinted, 'image') +
+      ' (out of ' +
+      total +
+      ') without a decoding hint. Add decoding="async" to non-critical images so the browser can decode them off the main thread.';
+  }
+
+  return {
+    id: 'decodingAsync',
+    title: 'Add decoding="async" to non-critical images',
+    description:
+      'Setting decoding="async" on an <img> tells the browser it can decode the image off the main thread, which keeps the page responsive to user interactions while images are being processed. The default ("auto") leaves the choice to the browser. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#decoding',
+    advice: advice,
+    score: score,
+    weight: 2,
+    severity: 'info',
+    offending: offending,
+    tags: ['performance', 'image']
+  };
+})(util);

--- a/lib/dom/performance/largestContentfulPaint.js
+++ b/lib/dom/performance/largestContentfulPaint.js
@@ -41,18 +41,9 @@
         offending.push(lcp.url || lcp.tag);
       }
 
-      if (lcp.tagName === 'IMG') {
-        if (largestEntry.element.fetchPriority != 'high') {
-          score -= 5;
-          advice +=
-            ' You can add fetchPriority="high" to the image to increase the load priority in Chrome.';
-        }
-        if (largestEntry.element.loading === 'lazy') {
-          score -= 20;
-          advice +=
-            ' The image is lazy loaded using the lazy attribute, you should avoid that on the LCP image.';
-        }
-      }
+      // Note: the priority-hint checks (fetchpriority="high",
+      // loading="lazy") that used to live here moved to the
+      // lcpImageHints rule so the two concerns score independently.
     }
   }
 

--- a/lib/dom/performance/lazyLoadingImages.js
+++ b/lib/dom/performance/lazyLoadingImages.js
@@ -1,0 +1,71 @@
+(function (util) {
+  'use strict';
+  // Below-the-fold images should use loading="lazy" so they don't
+  // compete with the initial render for bandwidth and decode time. The
+  // LCP rule already flags lazy-loading on the LCP image (which would
+  // be wrong); this rule covers the other side — images that are below
+  // the fold and could benefit from being lazy but aren't.
+  //
+  // We treat anything whose top is more than one viewport below the
+  // current scroll position as below-the-fold. That's a deliberate
+  // overshoot: images just below the fold often need to render before
+  // the user reaches them, so we only flag the ones that are clearly
+  // out of sight.
+  const viewportHeight =
+    window.innerHeight || document.documentElement.clientHeight || 0;
+  const foldCutoff = viewportHeight * 2;
+
+  const offending = [];
+  let belowFoldCount = 0;
+  const images = document.getElementsByTagName('img');
+
+  for (let i = 0, len = images.length; i < len; i++) {
+    const img = images[i];
+    if (!img.src && !img.currentSrc) {
+      continue;
+    }
+    let rect;
+    try {
+      rect = img.getBoundingClientRect();
+      // eslint-disable-next-line no-unused-vars
+    } catch (e) {
+      continue;
+    }
+    // Skip non-rendered images (display:none etc.) — they have zero
+    // height and aren't competing for anything.
+    if (rect.height === 0 && rect.width === 0) {
+      continue;
+    }
+    if (rect.top < foldCutoff) {
+      continue;
+    }
+    belowFoldCount++;
+    if ((img.loading || '').toLowerCase() !== 'lazy') {
+      offending.push(util.getAbsoluteURL(img.currentSrc || img.src));
+    }
+  }
+
+  let score = 100;
+  let advice = '';
+  if (offending.length > 0) {
+    const ratio = offending.length / Math.max(belowFoldCount, 1);
+    score = Math.round(100 * (1 - ratio));
+    advice =
+      'The page has ' +
+      util.plural(offending.length, 'below-the-fold image') +
+      ' without loading="lazy". Add loading="lazy" so the browser defers downloading and decoding them until the user scrolls them into view.';
+  }
+
+  return {
+    id: 'lazyLoadingImages',
+    title: 'Lazy-load below-the-fold images',
+    description:
+      'Adding loading="lazy" to an <img> tells the browser not to download or decode it until it is close to the viewport. For images that the user may never see (deep in the page, behind a tab, in a footer carousel), this saves bandwidth and main-thread time during initial render. The LCP image and any image in the initial viewport should NOT be lazy-loaded — that delays the first paint. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading',
+    advice: advice,
+    score: score,
+    weight: 4,
+    severity: 'warn',
+    offending: offending,
+    tags: ['performance', 'image']
+  };
+})(util);

--- a/lib/dom/performance/lcpImageHints.js
+++ b/lib/dom/performance/lcpImageHints.js
@@ -1,0 +1,73 @@
+(function () {
+  'use strict';
+  // The LCP image is the one element whose loading speed correlates
+  // most directly with the LCP metric, so two priority hints matter on
+  // it specifically:
+  //
+  //   * fetchpriority="high" tells the browser to fetch the image with
+  //     high priority instead of the default ("auto" — chosen by
+  //     internal heuristics that often guess wrong on hero images).
+  //   * loading="lazy" must NOT be set — a lazy LCP image is delayed
+  //     until intersection observation says it's near the viewport,
+  //     which by definition delays the LCP metric.
+  //
+  // The largestContentfulPaint rule scores the metric itself; this rule
+  // scores the priority hints applied to the element behind the metric.
+  // Splitting them lets a consumer tell apart "the hero image is slow"
+  // from "the hero image's hints are wrong" — different remediations.
+  let score = 100;
+  let advice = '';
+  const offending = [];
+
+  const supported = PerformanceObserver.supportedEntryTypes;
+  if (!supported || supported.indexOf('largest-contentful-paint') === -1) {
+    advice =
+      'Largest Contentful Paint is not supported in this browser, so the LCP image hints cannot be assessed.';
+  } else {
+    const observer = new PerformanceObserver(() => {});
+    observer.observe({ type: 'largest-contentful-paint', buffered: true });
+    const entries = observer.takeRecords();
+    if (entries.length === 0) {
+      advice = 'No LCP entries were observed during this snapshot.';
+    } else {
+      const entry = entries[entries.length - 1];
+      const el = entry.element;
+      if (!el || el.tagName !== 'IMG') {
+        // The LCP element is text or some other non-image. Nothing to
+        // score here; this rule is image-specific.
+        advice =
+          'The LCP element is not an image, so this rule does not apply.';
+      } else {
+        const tag = el.cloneNode(false).outerHTML;
+        const fetchpriority = (el.fetchPriority || '').toLowerCase();
+        const loading = (el.loading || '').toLowerCase();
+
+        if (loading === 'lazy') {
+          score -= 60;
+          advice +=
+            'The LCP image has loading="lazy", which delays its download until the browser thinks it is near the viewport — and so directly delays the LCP metric. Remove loading="lazy" from the LCP image. ';
+          offending.push(tag);
+        }
+        if (fetchpriority !== 'high') {
+          score -= 30;
+          advice +=
+            'The LCP image is missing fetchpriority="high". Adding it tells the browser to fetch the image with high priority instead of the default heuristic (which often deprioritises hero images that are loaded after the HTML has been parsed). ';
+          offending.push(tag);
+        }
+      }
+    }
+  }
+
+  return {
+    id: 'lcpImageHints',
+    title: 'Apply the right priority hints to the LCP image',
+    description:
+      'When the Largest Contentful Paint element is an image, the browser priority hints applied to that element directly affect the LCP metric. The image must NOT be loading="lazy" (that defers the fetch until near-viewport, which is the opposite of what an LCP image needs) and SHOULD be fetchpriority="high" (so the browser fetches it with high priority instead of guessing). https://web.dev/articles/fetch-priority',
+    advice: advice.trim(),
+    score: Math.max(0, score),
+    weight: 5,
+    severity: 'warn',
+    offending: offending,
+    tags: ['performance', 'image']
+  };
+})();

--- a/lib/dom/performance/modernImageFormats.js
+++ b/lib/dom/performance/modernImageFormats.js
@@ -1,0 +1,98 @@
+(function (util) {
+  'use strict';
+  // AVIF and WebP routinely deliver 25–50% smaller files than JPEG and
+  // PNG at the same perceived quality. Sites can ship them via:
+  //
+  //   * <picture> with one or more <source type="image/avif"> /
+  //     "image/webp"> elements before the JPEG/PNG fallback <img>;
+  //   * <img srcset> serving .avif / .webp candidates directly (with
+  //     content-negotiation upstream choosing the right format).
+  //
+  // We flag <img> elements that are NOT covered by either of those —
+  // i.e. plain JPEG/PNG/GIF with no modern alternative offered.
+  // Inline data: URIs and SVGs are skipped (different concerns).
+  const LEGACY_EXT_RE = /\.(jpe?g|png|gif|bmp)(?:[?#]|$)/i;
+  const MODERN_EXT_RE = /\.(avif|webp|jxl)(?:[?#]|$)/i;
+
+  function hasModernSourceSibling(img) {
+    let parent = img.parentElement;
+    if (!parent || parent.tagName !== 'PICTURE') {
+      return false;
+    }
+    const sources = parent.getElementsByTagName('source');
+    for (let i = 0; i < sources.length; i++) {
+      const type = (sources[i].getAttribute('type') || '').toLowerCase();
+      if (
+        type === 'image/avif' ||
+        type === 'image/webp' ||
+        type === 'image/jxl'
+      ) {
+        return true;
+      }
+      const srcset = sources[i].getAttribute('srcset') || '';
+      if (MODERN_EXT_RE.test(srcset)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function hasModernSrcset(img) {
+    const srcset = img.getAttribute('srcset') || '';
+    return MODERN_EXT_RE.test(srcset);
+  }
+
+  const offending = [];
+  let legacyOnly = 0;
+  let total = 0;
+  const images = document.getElementsByTagName('img');
+  for (let i = 0, len = images.length; i < len; i++) {
+    const img = images[i];
+    const src = img.currentSrc || img.src || '';
+    if (!src || src.indexOf('data:') === 0) {
+      continue;
+    }
+    // The image's own URL is already a modern format — fine.
+    if (MODERN_EXT_RE.test(src)) {
+      total++;
+      continue;
+    }
+    // Not a recognised raster format we can speak about (e.g. .svg,
+    // unknown extension, content-negotiated URL with no extension).
+    if (!LEGACY_EXT_RE.test(src)) {
+      continue;
+    }
+    total++;
+    if (hasModernSourceSibling(img) || hasModernSrcset(img)) {
+      continue;
+    }
+    legacyOnly++;
+    offending.push(util.getAbsoluteURL(src));
+  }
+
+  let score = 100;
+  let advice = '';
+  if (total > 0 && legacyOnly > 0) {
+    const ratio = legacyOnly / total;
+    score = Math.round(100 * (1 - ratio));
+    advice =
+      'The page ships ' +
+      util.plural(legacyOnly, 'image') +
+      ' (out of ' +
+      total +
+      ') in JPEG/PNG/GIF without a modern alternative. Wrap them in a <picture> with a <source type="image/avif"> or "image/webp" before the legacy <img>, or serve modern formats from your image pipeline directly. AVIF and WebP usually deliver 25–50% smaller files at the same quality.';
+  }
+
+  return {
+    id: 'modernImageFormats',
+    title: 'Serve images in modern formats (AVIF, WebP)',
+    description:
+      'AVIF and WebP routinely deliver 25–50% smaller files than JPEG and PNG at the same perceived quality, and every browser version still under support understands at least one of them. Ship modern formats either through a <picture> element with <source type="image/avif"> / "image/webp" entries in front of the legacy <img>, or directly from a content-negotiating image pipeline that returns AVIF / WebP when the client accepts it. https://web.dev/articles/serve-images-webp',
+    advice: advice,
+    score: score,
+    weight: 4,
+    severity: 'warn',
+    offending: offending,
+    tags: ['performance', 'image']
+  };
+})(util);


### PR DESCRIPTION
  Four new DOM performance rules and a small refactor of the existing LCP rule:

  - decodingAsync: flag  elements without a decoding hint. Pages benefit from decoding="async" on non-LCP images so decode work doesn't block the main thread.
  - lazyLoadingImages: flag below-the-fold  elements that aren't loading="lazy". Below-the-fold is more than two viewport heights below the current scroll position — a deliberate overshoot so images just below the visible area aren't penalised.
  - modernImageFormats: flag  elements that ship a JPEG/PNG/GIF without a modern alternative offered through  +  or via the 's own srcset. AVIF and WebP routinely deliver 25-50% smaller files at the same perceived quality.
  - lcpImageHints: when the LCP element is an image, score the priority hints on it — fetchpriority="high" (recommended) and loading="lazy" (forbidden, severely penalised). The largestContentfulPaint rule used to mix these checks into its own scoring, which double-counted "slow LCP" with "wrong hints on LCP". Splitting them lets a consumer tell apart "the hero image is slow" from "the hero image's hints are wrong" — different remediations.

  Co-authored-by: Claude (Opus 4.7) noreply@anthropic.com