### PR TITLE
Declare explicit severity on the seven remaining 9.0 rules

### DIFF
--- a/lib/dom/bestpractice/imageAltText.js
+++ b/lib/dom/bestpractice/imageAltText.js
@@ -37,6 +37,7 @@
         : '',
     score: score,
     weight: 4,
+    severity: 'info',
     offending: offending,
     tags: ['bestpractice', 'accessibility']
   };

--- a/lib/dom/bestpractice/viewport.js
+++ b/lib/dom/bestpractice/viewport.js
@@ -53,6 +53,7 @@
     advice: advice.trim(),
     score: Math.max(0, score),
     weight: 5,
+    severity: 'warn',
     offending: [],
     tags: ['bestpractice']
   };

--- a/lib/dom/privacy/iframeSandbox.js
+++ b/lib/dom/privacy/iframeSandbox.js
@@ -41,6 +41,7 @@
         : '',
     score: score,
     weight: 4,
+    severity: 'info',
     offending: offending,
     tags: ['privacy']
   };

--- a/lib/dom/privacy/referrerPolicy.js
+++ b/lib/dom/privacy/referrerPolicy.js
@@ -32,6 +32,7 @@
         : '',
     score: score,
     weight: 3,
+    severity: 'warn',
     offending: [],
     tags: ['privacy']
   };

--- a/lib/har/privacy/crossOriginEmbedderPolicyHeader.js
+++ b/lib/har/privacy/crossOriginEmbedderPolicyHeader.js
@@ -5,6 +5,7 @@ export default {
   description:
     'Cross-Origin-Embedder-Policy (COEP) makes the page refuse to load cross-origin subresources unless they explicitly opt in via CORP or CORS. Together with Cross-Origin-Opener-Policy it puts the page in a cross-origin isolated context, which mitigates cross-window side-channel attacks (Spectre) and unlocks high-resolution timers and SharedArrayBuffer. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy',
   weight: 4,
+  severity: 'info',
   tags: ['headers', 'privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/crossOriginOpenerPolicyHeader.js
+++ b/lib/har/privacy/crossOriginOpenerPolicyHeader.js
@@ -5,6 +5,7 @@ export default {
   description:
     'Cross-Origin-Opener-Policy (COOP) lets a page sever its window-group ties to cross-origin documents that opened it or that it opens. Together with Cross-Origin-Embedder-Policy it puts the page in a cross-origin isolated context, which mitigates cross-window side-channel attacks (Spectre) and unlocks high-resolution timers and SharedArrayBuffer. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy',
   weight: 4,
+  severity: 'warn',
   tags: ['headers', 'privacy'],
   processPage: function (page) {
     const offending = [];

--- a/lib/har/privacy/crossOriginResourcePolicyHeader.js
+++ b/lib/har/privacy/crossOriginResourcePolicyHeader.js
@@ -5,6 +5,7 @@ export default {
   description:
     'Cross-Origin-Resource-Policy (CORP) is a per-response opt-in that tells the browser which origins are allowed to embed the resource. It blocks cross-origin or cross-site no-cors embedding (img, script, iframe, etc.) and is one of the building blocks of cross-origin isolation. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy',
   weight: 3,
+  severity: 'info',
   tags: ['headers', 'privacy'],
   processPage: function (page) {
     const offending = [];


### PR DESCRIPTION
The 9.0.0-alpha.1 changelog already noted that newer rules should declare severity directly so the value reflects editorial intent rather than the arithmetic guess severity.fromWeight() makes from weight. Seven of the rules added in alpha.1 still leaned on that fallback — five privacy/security headers and two DOM best-practice checks. Picked editorially:

- dom/bestpractice/viewport.js → warn (mobile UX regression)
- dom/bestpractice/imageAltText.js → info
- dom/privacy/iframeSandbox.js → info
- dom/privacy/referrerPolicy.js → warn
- har/privacy/crossOriginOpenerPolicyHeader.js → warn
- har/privacy/crossOriginEmbedderPolicyHeader.js → info
- har/privacy/crossOriginResourcePolicyHeader.js → info

The two har/info/*.js files originally flagged are info collectors, not advice rules — no title / score / weight, no severity needed.

Co-authored-by: Claude Opus 4.7 noreply@anthropic.com