### PR TITLE
Skip mimeType validation for 204 No Content responses

### DIFF
--- a/lib/har/performance/mimeTypes.js
+++ b/lib/har/performance/mimeTypes.js
@@ -12,7 +12,12 @@ export default {
     let score = 100;
     let offending = [];
     page.assets.forEach(function (asset) {
-      if (asset.type == 'other' && asset.status > 199 && asset.status < 300) {
+      if (
+        asset.type == 'other' &&
+        asset.status > 199 &&
+        asset.status < 300 &&
+        asset.status != 204
+      ) {
         score--;
         offending.push(asset.url);
       }


### PR DESCRIPTION
## Goal
Skip mimeType validation when the response status is 204 (No Content).

A 204 response must not include a message body. 
Per MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/204

RFC 2616 §7.2.1, a `Content-Type` header is only required when a message body is present:
https://datatracker.ietf.org/doc/html/rfc2616#section-7.2.1