### PR TITLE
Drop NEL and Reporting-Endpoints from the score calculation

### DIFF
--- a/lib/har/privacy/nelHeader.js
+++ b/lib/har/privacy/nelHeader.js
@@ -3,7 +3,7 @@ export default {
   title: 'Set a NEL header so the browser reports network errors back to you.',
   description:
     'The NEL (Network Error Logging) response header tells the browser to record connection-level failures (DNS, TLS, HTTP errors) and ship them to a reporting endpoint. NEL pairs with the Reporting-Endpoints / Report-To header — the page declares the endpoint group and NEL points at it. Together they give you visibility into errors that never reach your origin server. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/NEL',
-  weight: 2,
+  weight: 0,
   severity: 'info',
   tags: ['headers', 'privacy', 'observability'],
   processPage: function (page) {

--- a/lib/har/privacy/reportingEndpointsHeader.js
+++ b/lib/har/privacy/reportingEndpointsHeader.js
@@ -4,7 +4,7 @@ export default {
     'Declare reporting endpoints so the browser can deliver Reporting-API events.',
   description:
     'The Reporting-Endpoints response header (the successor to Report-To) names the URLs that browsers should POST reports to. Without it, CSP report-to directives, Cross-Origin-Opener-Policy reports, NEL data and other Reporting-API events have nowhere to go. The legacy Report-To header is still accepted for older Chromium versions. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Reporting-Endpoints',
-  weight: 2,
+  weight: 0,
   severity: 'info',
   tags: ['headers', 'privacy', 'observability'],
   processPage: function (page) {


### PR DESCRIPTION
Both rules are already tagged severity: 'info' and they describe genuinely opt-in observability headers — most sites won't have a reporting endpoint to point them at, and they shouldn't be docked score for that. Set their weight to 0 (the same pattern mimeTypes.js already uses) so the advice keeps surfacing as informational but doesn't subtract from the privacy score.

Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com