### PR TITLE
Drop unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "filter-files": "0.4.0",
-        "json-stable-stringify": "1.0.2",
         "lodash.groupby": "4.6.0",
         "lodash.merge": "4.6.2",
-        "lodash.sortby": "4.7.0",
         "pagexray": "5.0.0",
         "third-party-web": "0.29.0",
         "wappalyzer-core": "6.10.54"
       },
       "devDependencies": {
-        "bookmarkletify": "^1.0.0",
         "browsertime": "27.0.0",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
@@ -1504,23 +1501,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/bookmarkletify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/bookmarkletify/-/bookmarkletify-1.0.0.tgz",
-      "integrity": "sha512-ohDM1EQoG7s2wIwgqGA7qMb7digOZHbS3/eMc3XftapPlP+xuc1Ii2UOoM+I6CzXYkDi5NiYxEkWsGLEwUEH7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "^1.4.7",
-        "nomnom": "^1.8.1",
-        "string-to-stream": "^1.0.0",
-        "uglify-js": "~1.3.4",
-        "vows": "~0.6.4"
-      },
-      "bin": {
-        "bookmarkletify": "bin/bookmarkletify"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -1909,22 +1889,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "node_modules/connect": {
       "version": "3.7.0",
@@ -2468,15 +2432,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
-      "dev": true,
-      "engines": {
-        "node": "> 0.1.90"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2853,16 +2808,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha512-kaNz5OTAYYmt646Hkqw50/qyxP2vFnTVu5AQ1Zmk22Kk5+4Qx6BpO8+u7IKsML5fOsFk0ZT0AcCJNYwcvaLBvw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3212,33 +3157,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
-      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
-      "license": "MIT",
-      "dependencies": {
-        "jsonify": "^0.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -3297,12 +3221,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -3739,55 +3657,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/antelle"
-      }
-    },
-    "node_modules/nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha512-5s0JxqhDx9/rksG2BTMVN1enjWSvPidpoSgViZU4ZXULyTe+7jxcCRLB6f42Z0l1xYJpleCBtSyY6Lwg3uu5CQ==",
-      "deprecated": "Package no longer supported. Contact support@npmjs.com for more info.",
-      "dev": true,
-      "dependencies": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      }
-    },
-    "node_modules/nomnom/node_modules/ansi-styles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-      "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/nomnom/node_modules/chalk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-      "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "~1.0.0",
-        "has-color": "~0.1.0",
-        "strip-ansi": "~0.1.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/nomnom/node_modules/strip-ansi": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-      "integrity": "sha512-behete+3uqxecWlDAm5lmskaSaISA+ThQ4oNNBDTBJt0x2ppR6IPqfZNuj6BLaLJ/Sji4TPZlcRyOis8wXQTLg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/normalize-path": {
@@ -4643,17 +4512,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/string-to-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
-      "integrity": "sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.1.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4943,22 +4801,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/uglify-js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
-      "integrity": "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ==",
-      "dev": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      }
-    },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
@@ -4972,12 +4814,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==",
-      "dev": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
@@ -5081,28 +4917,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/vows": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/vows/-/vows-0.6.4.tgz",
-      "integrity": "sha512-CnnxhTuz08RHlAEagUSH6806IMxlOvYK5Nz5CyRGaqk9m2qVsP/0vtNBtU9rUS0TTrx3JYmPtHwIELaf+91t0Q==",
-      "dev": true,
-      "dependencies": {
-        "diff": "~1.0.3",
-        "eyes": ">=0.1.6"
-      },
-      "bin": {
-        "vows": "bin/vows"
-      }
-    },
-    "node_modules/vows/node_modules/diff": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-      "integrity": "sha512-1zEb73vemXFpUmfh3fsta4YHz3lwebxXvaWmPbFv9apujQBWDnkrPDLXLQs1gZo4RCWMDsT89r0Pf/z8/02TGA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/wappalyzer-core": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "devDependencies": {
     "browsertime": "27.0.0",
-    "bookmarkletify": "^1.0.0",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "connect": "^3.7.0",
@@ -78,10 +77,8 @@
   ],
   "dependencies": {
     "filter-files": "0.4.0",
-    "json-stable-stringify": "1.0.2",
     "lodash.groupby": "4.6.0",
     "lodash.merge": "4.6.2",
-    "lodash.sortby": "4.7.0",
     "pagexray": "5.0.0",
     "third-party-web": "0.29.0",
     "wappalyzer-core": "6.10.54"


### PR DESCRIPTION
  Three packages were declared but referenced nowhere in source:
  bookmarkletify, json-stable-stringify, and lodash.sortby. Removing them
  shrinks the install surface without any code change.

  Co-authored-by: Claude noreply@anthropic.com