### PR TITLE
Replace lodash.merge with a small local helper

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
 import pagexray from 'pagexray';
 import thirdPartyWeb from 'third-party-web';
-import lodashMerge from 'lodash.merge';
+import { merge as mergeObjects } from './support/objectMerge.js';
 import { merge as merger } from './merge.js';
 import { pickAPage as pickAPageImpl } from './har/harCutter.js';
 import { runAdvice } from './har/index.js';
@@ -65,7 +65,7 @@ export async function analyseHar(har, harAdvice, domAdviceResult, options) {
     harAdvice = await getHarAdvice();
   }
 
-  options = lodashMerge({}, options);
+  options = mergeObjects({}, options);
   return runAdvice(
     getPagesFromHar(har, options),
     harAdvice,

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,4 +1,4 @@
-import lodashMerge from 'lodash.merge';
+import { merge as mergeObjects } from './support/objectMerge.js';
 import * as severity from './severity.js';
 
 function recalculateScore(results) {
@@ -39,6 +39,6 @@ function recalculateScore(results) {
 }
 
 export function merge(domResult, harResult) {
-  const result = lodashMerge(domResult, harResult[0]);
+  const result = mergeObjects(domResult, harResult[0]);
   return recalculateScore(result);
 }

--- a/lib/support/objectMerge.js
+++ b/lib/support/objectMerge.js
@@ -1,0 +1,45 @@
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isNullish(value) {
+  return value === undefined || value === null;
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function canMergeInto(value) {
+  return value !== null && typeof value === 'object';
+}
+
+function mergeInto(target, source) {
+  for (const key of Object.keys(source)) {
+    if (FORBIDDEN_KEYS.has(key)) continue;
+    const sourceValue = source[key];
+    const targetValue = target[key];
+    if (Array.isArray(sourceValue)) {
+      const into = Array.isArray(targetValue) ? targetValue : [];
+      mergeInto(into, sourceValue);
+      target[key] = into;
+    } else if (isPlainObject(sourceValue)) {
+      const into = canMergeInto(targetValue) ? targetValue : {};
+      mergeInto(into, sourceValue);
+      target[key] = into;
+    } else if (sourceValue === undefined) {
+      if (!(key in target)) target[key] = undefined;
+    } else {
+      target[key] = sourceValue;
+    }
+  }
+}
+
+export function merge(target, ...sources) {
+  if (isNullish(target)) return target;
+  for (const source of sources) {
+    if (isNullish(source)) continue;
+    mergeInto(target, source);
+  }
+  return target;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "filter-files": "0.4.0",
         "lodash.groupby": "4.6.0",
-        "lodash.merge": "4.6.2",
         "pagexray": "5.0.0",
         "third-party-web": "0.29.0",
         "wappalyzer-core": "6.10.54"
@@ -3221,6 +3220,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
   "dependencies": {
     "filter-files": "0.4.0",
     "lodash.groupby": "4.6.0",
-    "lodash.merge": "4.6.2",
     "pagexray": "5.0.0",
     "third-party-web": "0.29.0",
     "wappalyzer-core": "6.10.54"


### PR DESCRIPTION
  Coach-core used lodash.merge in only two spots — to clone an options object
  in analyseHar before passing it along, and to fold the HAR result into the
  DOM result before recalculating scores. Both rely on lodash's deep-merge
  semantics: arrays merged by index, undefined values skipped unless the key
  is missing on target, plain objects treated differently from Date/RegExp.

  The new merge in lib/support/objectMerge.js is the same helper that
  sitespeed.io now uses in place of lodash.merge, where it was verified
  against the original across 23 edge cases. Pulling that proven helper into
  coach-core lets us drop the runtime dependency without introducing new
  behaviour to vet.

  Co-authored-by: Claude noreply@anthropic.com