### PR TITLE
Replace lodash.groupby with a small inline helper

### DIFF
--- a/lib/har/harCutter.js
+++ b/lib/har/harCutter.js
@@ -1,4 +1,11 @@
-import groupBy from 'lodash.groupby';
+function groupBy(items, key) {
+  const result = {};
+  for (const item of items) {
+    const bucket = item[key];
+    (result[bucket] ||= []).push(item);
+  }
+  return result;
+}
 
 export function pickAPage(har, pageIndex) {
   if (typeof har.log.pages[pageIndex] !== 'undefined') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "filter-files": "0.4.0",
-        "lodash.groupby": "4.6.0",
         "pagexray": "5.0.0",
         "third-party-web": "0.29.0",
         "wappalyzer-core": "6.10.54"
@@ -3209,12 +3208,6 @@
       "dependencies": {
         "immediate": "~3.0.5"
       }
-    },
-    "node_modules/lodash.groupby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
-      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
-      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   ],
   "dependencies": {
     "filter-files": "0.4.0",
-    "lodash.groupby": "4.6.0",
     "pagexray": "5.0.0",
     "third-party-web": "0.29.0",
     "wappalyzer-core": "6.10.54"


### PR DESCRIPTION
  The single use site in harCutter groups HAR entries by their pageref so the
  right subset can be picked out for a given page. It is a trivial loop, and
  keeping a dedicated lodash.* package around for one call was hard to
  justify. Inlining the helper removes the last lodash runtime dependency
  from coach-core.

  Co-authored-by: Claude noreply@anthropic.com