### PR TITLE
Drop filter-files and mkdirp in favour of native fs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "9.1.0",
       "license": "MIT",
       "dependencies": {
-        "filter-files": "0.4.0",
         "pagexray": "5.0.0",
         "third-party-web": "0.29.0",
         "wappalyzer-core": "6.10.54"
@@ -22,7 +21,6 @@
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
-        "mkdirp": "^3.0.1",
         "mocha": "^10.2.0",
         "prettier": "^3.4.2",
         "serve-static": "^1.16.2",
@@ -1447,12 +1445,6 @@
         "node": "*"
       }
     },
-    "node_modules/async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha512-l6ToIJIotphWahxxHyzK9bnLR6kM4jJIIgLShZeqLY7iboHoGkdgFl7W2/Ivi4SkMJYGKqW8vSuk0uKUj6qsSw==",
-      "license": "MIT"
-    },
     "node_modules/await-to-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
@@ -2537,18 +2529,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/filter-files": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/filter-files/-/filter-files-0.4.0.tgz",
-      "integrity": "sha512-GdvMk8r98FmuSLErSnWzfRIylY1OWLMxlN6YmG6/JZp3dIBZUzcEGyoiSu+hM+bnwGuUS1msQ7raGB5iWeSP/g==",
-      "dependencies": {
-        "async": "^0.9.0",
-        "is-directory": "^0.2.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -2976,14 +2956,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-directory": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.2.3.tgz",
-      "integrity": "sha512-XbnAq9Uw37vufdlDOgjxcw1DSnq864NssIgtD7WN4SJtLxUXtJlHtAfBBPO3CdCgdKbqIKTZrmvzwxNnU4LhHQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3349,22 +3321,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/sitespeedio/coach-core/issues"
   },
   "scripts": {
-    "combine": "mkdirp dist && node tools/combine.js dist/coach.js",
+    "combine": "node tools/combine.js dist/coach.js",
     "test:api": "mocha --recursive test/api",
     "test:dom": "mocha --recursive test/dom",
     "test:har": "mocha --recursive test/har",
@@ -55,7 +55,6 @@
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "mkdirp": "^3.0.1",
     "mocha": "^10.2.0",
     "prettier": "^3.4.2",
     "serve-static": "^1.16.2",
@@ -76,7 +75,6 @@
     }
   ],
   "dependencies": {
-    "filter-files": "0.4.0",
     "pagexray": "5.0.0",
     "third-party-web": "0.29.0",
     "wappalyzer-core": "6.10.54"

--- a/tools/combine.js
+++ b/tools/combine.js
@@ -1,18 +1,25 @@
 #!/usr/bin/env node
 
-import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, basename, extname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
-import filter from 'filter-files';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const packageInfo = require('../package.json');
 
-const filterJsFiles = (file) => extname(file) === '.js';
-const filterDirs = (file, dir) =>
-  statSync(resolve(dir, file)).isDirectory();
+function listDirs(dir) {
+  return readdirSync(dir)
+    .map((name) => resolve(dir, name))
+    .filter((path) => statSync(path).isDirectory());
+}
+
+function listJsFiles(dir) {
+  return readdirSync(dir)
+    .filter((name) => extname(name) === '.js')
+    .map((name) => resolve(dir, name));
+}
 
 const fileContentsByName = (scripts, file) => {
   const name = basename(file, '.js');
@@ -27,13 +34,16 @@ export default function combine(filename) {
     ),
     categoriesPath = join(__dirname, '../lib/dom');
 
-  const categoryDirs = filter.sync(categoriesPath, filterDirs, false);
+  mkdirSync(dirname(filename), { recursive: true });
+
+  const categoryDirs = listDirs(categoriesPath);
 
   const scriptsByCategory = categoryDirs.reduce((byCategory, categoryDir) => {
     const categoryName = basename(categoryDir);
-    byCategory[categoryName] = filter
-      .sync(categoryDir, filterJsFiles, false)
-      .reduce(fileContentsByName, {});
+    byCategory[categoryName] = listJsFiles(categoryDir).reduce(
+      fileContentsByName,
+      {}
+    );
     return byCategory;
   }, {});
 


### PR DESCRIPTION
  The combine build step used filter-files to enumerate category directories
  and JS files under lib/dom, and mkdirp in an npm script to create the dist
  output directory. Both jobs are a few lines of node:fs (readdirSync,
  statSync, mkdirSync recursive), so the dependencies were carrying their
  weight purely to spell those primitives.

  The combine script now ensures its own output directory exists, which lets
  the npm script collapse to a single node call. With this change coach-core
  ships with three runtime dependencies — pagexray, third-party-web,
  wappalyzer-core — and no incidental ones.

  Co-authored-by: Claude noreply@anthropic.com