### PR TITLE
Backfill HAR tests for the privacy, bestpractice and info rules

### DIFF
--- a/test/har/bestpractice/thirdPartyTest.js
+++ b/test/har/bestpractice/thirdPartyTest.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Avoid too many third party requests / scores 0 when third-party traffic dominates the page', async (t) => {
+  // www.nytimes.com.har has more requests and bytes from third-party
+  // domains than first-party. The rule deducts 50 for the request
+  // imbalance and 50 again for the byte imbalance — clamped to 0.
+  const result = await har.firstAdviceForTestFile('www.nytimes.com.har', {
+    firstParty: 'nytimes\\.com'
+  });
+  const advice = result.bestpractice.adviceList.thirdParty;
+  t.is(advice.score, 0);
+  t.regex(advice.advice, /third party/i);
+});
+
+test('Avoid too many third party requests / does not flag a page where first-party traffic dominates', async (t) => {
+  // referrerPolicy.har is a small sitespeed.io document where the
+  // document itself is the bulk of traffic — the rule should not deduct.
+  const result = await har.firstAdviceForTestFile('referrerPolicy.har');
+  const advice = result.bestpractice.adviceList.thirdParty;
+  t.is(advice.score, 100);
+});

--- a/test/har/info/thirdPartyTest.js
+++ b/test/har/info/thirdPartyTest.js
@@ -1,0 +1,27 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Third-party info / surfaces third-party requests grouped by category', async (t) => {
+  const result = await har.firstAdviceForTestFile('www.nytimes.com.har', {
+    firstParty: 'nytimes\\.com'
+  });
+  const info = result.info.thirdparty;
+  t.true(info.totalThirdPartyRequests > 0);
+  t.true(info.thirdPartyTransferSizeBytes > 0);
+  // nytimes pulls in ad / analytics / surveillance services that
+  // third-party-web categorises.
+  t.true(Object.keys(info.byCategory).length > 0);
+  t.truthy(info.toolsByCategory);
+});
+
+test('Third-party info / always returns the expected shape', async (t) => {
+  // Even on a small document, the helper should return the same shape so
+  // downstream consumers can rely on it.
+  const result = await har.firstAdviceForTestFile('referrerPolicy.har');
+  const info = result.info.thirdparty;
+  t.true('totalThirdPartyRequests' in info);
+  t.true('thirdPartyTransferSizeBytes' in info);
+  t.true('byCategory' in info);
+  t.true('toolsByCategory' in info);
+  t.true('offending' in info);
+});

--- a/test/har/performance/avoidRenderBlockingTest.js
+++ b/test/har/performance/avoidRenderBlockingTest.js
@@ -1,0 +1,25 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Avoid render blocking (HAR) / produces no score when the browser is not Chrome/Edge', async (t) => {
+  // The HAR-level rule only reports for Chrome/Edge runs because it
+  // relies on the Chrome devtools renderBlocking metadata. Without a
+  // browser option set, the rule short-circuits and the runner ends up
+  // emitting only the advice metadata — no `score`, no `offending`.
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.performance.adviceList.avoidRenderBlocking;
+  t.is(advice.score, undefined);
+  t.is(advice.offending, undefined);
+});
+
+test('Avoid render blocking (HAR) / scores 100 on a Chrome HAR with no renderBlocking metadata', async (t) => {
+  // Pass browser=chrome to opt into the rule. Without renderBlocking
+  // metadata on the assets, the rule has nothing to flag and reports
+  // a clean run.
+  const result = await har.firstAdviceForTestFile('manyHeaders.har', {
+    browser: 'chrome'
+  });
+  const advice = result.performance.adviceList.avoidRenderBlocking;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});

--- a/test/har/privacy/crossOriginEmbedderPolicyHeaderTest.js
+++ b/test/har/privacy/crossOriginEmbedderPolicyHeaderTest.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Cross-Origin-Embedder-Policy / flags the document when the header is missing', async (t) => {
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.privacy.adviceList.crossOriginEmbedderPolicyHeader;
+  t.is(advice.score, 0);
+  t.is(advice.offending.length, 1);
+});
+
+test('Cross-Origin-Embedder-Policy / accepts a require-corp value on the document', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  clone.log.entries[0].response.headers.push({
+    name: 'cross-origin-embedder-policy',
+    value: 'require-corp'
+  });
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.crossOriginEmbedderPolicyHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});

--- a/test/har/privacy/crossOriginOpenerPolicyHeaderTest.js
+++ b/test/har/privacy/crossOriginOpenerPolicyHeaderTest.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Cross-Origin-Opener-Policy / flags the document when the header is missing', async (t) => {
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.privacy.adviceList.crossOriginOpenerPolicyHeader;
+  t.is(advice.score, 0);
+  t.is(advice.offending.length, 1);
+});
+
+test('Cross-Origin-Opener-Policy / accepts a same-origin value on the document', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  clone.log.entries[0].response.headers.push({
+    name: 'cross-origin-opener-policy',
+    value: 'same-origin'
+  });
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.crossOriginOpenerPolicyHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});

--- a/test/har/privacy/crossOriginResourcePolicyHeaderTest.js
+++ b/test/har/privacy/crossOriginResourcePolicyHeaderTest.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Cross-Origin-Resource-Policy / flags the document when the header is missing', async (t) => {
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.privacy.adviceList.crossOriginResourcePolicyHeader;
+  t.is(advice.score, 0);
+  t.is(advice.offending.length, 1);
+});
+
+test('Cross-Origin-Resource-Policy / accepts a same-origin value on the document', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  clone.log.entries[0].response.headers.push({
+    name: 'cross-origin-resource-policy',
+    value: 'same-origin'
+  });
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.crossOriginResourcePolicyHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});

--- a/test/har/privacy/googleReCaptchaTest.js
+++ b/test/har/privacy/googleReCaptchaTest.js
@@ -1,0 +1,33 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Google reCAPTCHA / does not flag a page without reCAPTCHA', async (t) => {
+  const result = await har.firstAdviceForTestFile('referrerPolicy.har');
+  const advice = result.privacy.adviceList.googleReCaptcha;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});
+
+test('Google reCAPTCHA / flags a page that loads recaptcha/api.js', async (t) => {
+  const base = await har.harFromTestFile('referrerPolicy.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  const recaptchaEntry = JSON.parse(JSON.stringify(clone.log.entries[0]));
+  recaptchaEntry.request.url = 'https://www.google.com/recaptcha/api.js';
+  clone.log.entries.push(recaptchaEntry);
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.googleReCaptcha;
+  t.is(advice.score, 0);
+  t.true(advice.offending.length >= 1);
+});
+
+test('Google reCAPTCHA / also flags the Enterprise variant', async (t) => {
+  const base = await har.harFromTestFile('referrerPolicy.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  const recaptchaEntry = JSON.parse(JSON.stringify(clone.log.entries[0]));
+  recaptchaEntry.request.url =
+    'https://www.google.com/recaptcha/enterprise.js?render=foo';
+  clone.log.entries.push(recaptchaEntry);
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.googleReCaptcha;
+  t.is(advice.score, 0);
+});

--- a/test/har/privacy/mixedContentTest.js
+++ b/test/har/privacy/mixedContentTest.js
@@ -1,0 +1,31 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Mixed content / does not flag an HTTPS page with no HTTP assets', async (t) => {
+  // referrerPolicy.har is an https://www.sitespeed.io/ document with all
+  // assets served over HTTPS.
+  const result = await har.firstAdviceForTestFile('referrerPolicy.har');
+  const advice = result.privacy.adviceList.mixedContent;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});
+
+test('Mixed content / flags an HTTPS page with HTTP assets', async (t) => {
+  const base = await har.harFromTestFile('referrerPolicy.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  const httpEntry = JSON.parse(JSON.stringify(clone.log.entries[0]));
+  httpEntry.request.url = 'http://insecure.example.com/image.png';
+  clone.log.entries.push(httpEntry);
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.mixedContent;
+  t.is(advice.score, 0);
+  t.true(advice.offending.length >= 1);
+});
+
+test('Mixed content / does not check assets when the page itself is HTTP', async (t) => {
+  // www.nytimes.com.har is an http:// page; the rule short-circuits and
+  // returns score 100 without inspecting assets.
+  const result = await har.firstAdviceForTestFile('www.nytimes.com.har');
+  const advice = result.privacy.adviceList.mixedContent;
+  t.is(advice.score, 100);
+});

--- a/test/har/privacy/nelHeaderTest.js
+++ b/test/har/privacy/nelHeaderTest.js
@@ -1,0 +1,22 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('NEL header / flags the document when the header is missing', async (t) => {
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.privacy.adviceList.nelHeader;
+  t.is(advice.score, 0);
+  t.is(advice.offending.length, 1);
+});
+
+test('NEL header / accepts a NEL value on the document', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  clone.log.entries[0].response.headers.push({
+    name: 'nel',
+    value: '{"report_to":"default","max_age":2592000}'
+  });
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.nelHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});

--- a/test/har/privacy/permissionsPolicyHeaderTest.js
+++ b/test/har/privacy/permissionsPolicyHeaderTest.js
@@ -1,0 +1,35 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Permissions-Policy / flags the document when the header is missing', async (t) => {
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.privacy.adviceList.permissionsPolicyHeader;
+  t.is(advice.score, 0);
+  t.is(advice.offending.length, 1);
+});
+
+test('Permissions-Policy / accepts a Permissions-Policy value on the document', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  clone.log.entries[0].response.headers.push({
+    name: 'permissions-policy',
+    value: 'camera=(), microphone=(), geolocation=()'
+  });
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.permissionsPolicyHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});
+
+test('Permissions-Policy / also accepts the legacy Feature-Policy header', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  clone.log.entries[0].response.headers.push({
+    name: 'feature-policy',
+    value: "camera 'none'; microphone 'none'"
+  });
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.permissionsPolicyHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});

--- a/test/har/privacy/reportingEndpointsHeaderTest.js
+++ b/test/har/privacy/reportingEndpointsHeaderTest.js
@@ -1,0 +1,36 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Reporting-Endpoints / flags the document when the header is missing', async (t) => {
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.privacy.adviceList.reportingEndpointsHeader;
+  t.is(advice.score, 0);
+  t.is(advice.offending.length, 1);
+});
+
+test('Reporting-Endpoints / accepts a Reporting-Endpoints value on the document', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  clone.log.entries[0].response.headers.push({
+    name: 'reporting-endpoints',
+    value: 'default="https://example.com/reports"'
+  });
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.reportingEndpointsHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});
+
+test('Reporting-Endpoints / also accepts the legacy Report-To header', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  clone.log.entries[0].response.headers.push({
+    name: 'report-to',
+    value:
+      '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://example.com/reports"}]}'
+  });
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.reportingEndpointsHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});

--- a/test/har/privacy/thirdPartyCookiesTest.js
+++ b/test/har/privacy/thirdPartyCookiesTest.js
@@ -1,0 +1,21 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Third-party cookies / scores 0 on a page with many third-party cookies', async (t) => {
+  // www.nytimes.com.har is a real-world fixture loaded with third-party
+  // cookies; the rule deducts 10 points per cookie and clamps at 0.
+  const result = await har.firstAdviceForTestFile('www.nytimes.com.har', {
+    firstParty: 'nytimes\\.com'
+  });
+  const advice = result.privacy.adviceList.thirdPartyCookies;
+  t.is(advice.score, 0);
+  t.true(advice.offending.length > 0);
+});
+
+test('Third-party cookies / scores 100 on a page with no third-party cookies', async (t) => {
+  // manyHeaders.har is a single-document HAR with no third-party cookies.
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.privacy.adviceList.thirdPartyCookies;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});

--- a/test/har/privacy/thirdPartyPrivacyTest.js
+++ b/test/har/privacy/thirdPartyPrivacyTest.js
@@ -1,0 +1,25 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('Third-party privacy / scores 0 on a page with surveillance third parties', async (t) => {
+  // www.nytimes.com.har has third-party requests categorised as
+  // "surveillance" by third-party-web — the rule clamps the score to 0
+  // when any surveillance request is detected.
+  const result = await har.firstAdviceForTestFile('www.nytimes.com.har', {
+    firstParty: 'nytimes\\.com'
+  });
+  const advice = result.privacy.adviceList.thirdPartyPrivacy;
+  t.is(advice.score, 0);
+  t.regex(advice.advice, /surveillance|harvest data/i);
+});
+
+test('Third-party privacy / deducts proportional to the third-party share', async (t) => {
+  // referrerPolicy.har is an https://www.sitespeed.io/ document with only
+  // a handful of requests, none of them surveillance-categorised. The
+  // rule should produce a score that reflects the third-party share
+  // rather than clamping to 0.
+  const result = await har.firstAdviceForTestFile('referrerPolicy.har');
+  const advice = result.privacy.adviceList.thirdPartyPrivacy;
+  t.true(advice.score >= 0 && advice.score <= 100);
+  t.regex(advice.advice, /third party|3rd party/i);
+});

--- a/test/har/privacy/xContentTypeOptionsHeaderTest.js
+++ b/test/har/privacy/xContentTypeOptionsHeaderTest.js
@@ -1,0 +1,31 @@
+import test from 'ava';
+import har from '../../help/har.js';
+
+test('X-Content-Type-Options / accepts nosniff on the document', async (t) => {
+  // manyHeaders.har has `x-content-type-options: nosniff` on the document.
+  const result = await har.firstAdviceForTestFile('manyHeaders.har');
+  const advice = result.privacy.adviceList.xContentTypeOptionsHeader;
+  t.is(advice.score, 100);
+  t.is(advice.offending.length, 0);
+});
+
+test('X-Content-Type-Options / flags the document when nosniff is missing', async (t) => {
+  // www.nytimes.com.har is an older HAR with no X-Content-Type-Options on
+  // the document response.
+  const result = await har.firstAdviceForTestFile('www.nytimes.com.har');
+  const advice = result.privacy.adviceList.xContentTypeOptionsHeader;
+  t.is(advice.score, 0);
+  t.true(advice.offending.length >= 1);
+});
+
+test('X-Content-Type-Options / rejects values other than nosniff', async (t) => {
+  const base = await har.harFromTestFile('manyHeaders.har');
+  const clone = JSON.parse(JSON.stringify(base));
+  // Drop the existing nosniff entry and replace it with a non-canonical value.
+  clone.log.entries[0].response.headers = clone.log.entries[0].response.headers
+    .filter((h) => h.name.toLowerCase() !== 'x-content-type-options')
+    .concat([{ name: 'x-content-type-options', value: 'something-else' }]);
+  const result = await har.firstAdviceForHar(clone);
+  const advice = result.privacy.adviceList.xContentTypeOptionsHeader;
+  t.is(advice.score, 0);
+});

--- a/test/help/har.js
+++ b/test/help/har.js
@@ -20,4 +20,16 @@ export async function firstAdviceForTestFile(fileName, options) {
   return result[0].advice;
 }
 
-export default { harFromTestFile, firstAdviceForTestFile };
+// Run the advice pipeline against an in-memory HAR (typically a fixture clone
+// with a tweak applied). Returns the first page's advice block.
+export async function firstAdviceForHar(har, options) {
+  const advice = await api.getHarAdvice();
+  const result = await api.analyseHar(har, advice, undefined, options);
+  return result[0].advice;
+}
+
+export default {
+  harFromTestFile,
+  firstAdviceForTestFile,
+  firstAdviceForHar
+};


### PR DESCRIPTION
  Eleven of fourteen HAR privacy rules were shipping without a safety net,
  plus the HAR-level avoidRenderBlocking and the third-party rules in
  bestpractice / info. The header-based rules (cross-origin-*-policy,
  NEL, Reporting-Endpoints, Permissions-Policy, X-Content-Type-Options)
  each get a negative case against an existing fixture and a positive
  case built by cloning the fixture and pushing the target header on the
  document response — the same pattern technologyTest already used inline.
  The reCAPTCHA and mixed-content rules clone a fixture and inject a
  matching asset to exercise the positive path.

  bestpractice / info. The header-based rules (cross-origin-*-policy,
  NEL, Reporting-Endpoints, Permissions-Policy, X-Content-Type-Options)
  each get a negative case against an existing fixture and a positive
  case built by cloning the fixture and pushing the target header on the
  document response — the same pattern technologyTest already used inline.
  The reCAPTCHA and mixed-content rules clone a fixture and inject a
  matching asset to exercise the positive path.

  The third-party rules (privacy/thirdPartyPrivacy, bestpractice/thirdParty,
  info/thirdParty) lean on the existing http://www.nytimes.com.har fixture with
  the firstParty option set so pagexray classifies the off-domain assets
  correctly — that fixture has real surveillance-categorised tracking and
  exercises the score=0 branch end-to-end.

  A small firstAdviceForHar(har, options) helper was added to
  test/help/har.js so the clone-and-run pattern doesn't need to be copied
  around the new tests.

  Co-authored-by: Claude noreply@anthropic.com