### PR TITLE
Stop terser from negating the coach IIFE's return value

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint:fix": "eslint . --fix",
     "prepare": "npm run combine && npm run terser",
     "gen-dist": "npm run combine && npm run terser",
-    "terser": "terser dist/coach.js --compress --mangle --format wrap_iife=true --parse acorn > dist/coach.min.js"
+    "terser": "terser dist/coach.js --compress negate_iife=false --mangle --format wrap_iife=true --parse acorn > dist/coach.min.js"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
  The minified coach script is invoked in the browser via Selenium's
  executeScript by way of return ${script}, so the outer IIFE's return
  value IS the contract — sitespeed.io reads it back as
  browserScriptsData.coach.coachAdvice and expects an object with the
  collected advice, errors and version.

  Terser's negate_iife compress option rewrites a top-level
  (function(){…})() as !function(){…}() to shave a byte. That turned
  the advice object into false on the wire. The bug was latent: an old
  --compresss typo meant compression never ran, so the negation never
  happened. Once that typo was fixed (dd178ab) compression kicked in and
  sitespeed.io started seeing coachAdvice === false, then crashing the
  DOM/HAR merge and the html templates that assume DOM data exists.

  Disable negate_iife in the terser invocation so the IIFE keeps its
  return value.

  Co-authored-by: Claude Opus 4.7 (1M context) noreply@anthropic.com